### PR TITLE
Automated releases to PyPI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,10 @@
 sudo: false
 language: python
 python:
-- '2.7'
-- '3.4'
-- '3.5'
-- '3.6'
+  - '2.7'
+  - '3.4'
+  - '3.5'
+  - '3.6'
 install: pip install tox-travis
 script: tox
 notifications:
@@ -12,3 +12,25 @@ notifications:
     rooms:
       secure: piy/NEf36gPZqw4nTAhs6dZ7Af2ozOt47RdnTSaed3tkwMfXJ+M3nccuCP4UfwmBP7fRRq2yfhLWCKIZagsFGAxhNZ/mSYgRdXfNUUofOWIJdR4+tQuqhxwgQkTfJjAWlYA+gA+GxrOnSFQ3ACRnfd/dUfthokqq7CWOzQtYYHGBSA1rAxuJU1x2qWbl+1tXa7BUJXCsR8ONz7vWDna4Znk+wixG3enOdd2pdrP2dqp9g0eUztySIT2zdjA2CB4iFIIqQLJ5fz3ab8Vpk4H9+JECB7lE8+SJVS9ZbBu8vuD9yZARBJGCPyD8HcwHTNrvlTu/V9p9W+6OeNCUXamZFuCkMHIwLgDxUntG/IyCptJqtG1n/7dOxikY1kfAIIcwMsmTQDej3xXHny1wyGMztD84w23KhNEPMJP7HsLVHmt26TIiT/yFeIOzGnh2ZPenMwtn7ti8uiweEpAH2G3tmH6bShv8myXEp++RcblSNeowHpyFhRsoevuqpT+dd+C+as2Y1DWBSFqvrfCro7AKloErJHtS3GXUiAf1Fi+Vys/sj+PLQFBh88GR5OY0lDC1cTfA4iy3Vy0IICRIylkQ4W0jfbgKF6B40syA6rM0mlu1v15P9oJvI+P5N9/G8jhUA54Ku3Xxmd6qpzlFvx2ivxmPBfHNc7g7MHJZFlzlzvk=
     on_success: change
+
+deploy:
+  # Test PyPI in every change to master
+  - provider: pypi
+    server: https://test.pypi.org/legacy/
+    distributions: sdist bdist_wheel
+    user: $PYPI_TEST_USERNAME
+    password: $PYPI_TEST_PASSWORD
+    on:
+      branch: master
+      tags: false
+      python: 3.6
+
+  # Real PyPI in tags (ie. GitHub releases)
+  - provider: pypi
+    distributions: sdist bdist_wheel
+    user: $PYPI_USERNAME
+    password: $PYPI_PASSWORD
+    on:
+      branch: master
+      tags: true
+      python: 3.6

--- a/luminoth/__init__.py
+++ b/luminoth/__init__.py
@@ -1,6 +1,6 @@
 from luminoth.cli import cli  # noqa
 
-__version__ = '0.0.1.dev0'
+__version__ = '0.0.1.dev1'
 
 __title__ = 'Luminoth'
 __description__ = 'Computer vision toolkit based on TensorFlow'

--- a/setup.py
+++ b/setup.py
@@ -103,6 +103,7 @@ setup(
     long_description=read('README.md'),
     license=find_meta('license'),
     author=find_meta('author'),
+    author_email=find_meta('email'),
     maintainer=find_meta('author'),
     maintainer_email=find_meta('email'),
     url=find_meta('uri'),


### PR DESCRIPTION
This will:
* Release to [test PyPI](https://testpypi.python.org) on *every* change to `master`.
* Release to [real PyPI](https://pypi.python.org) the commits that are *tagged*.

Tags are made easily by creating a GitHub release. Don't need to forget to increment the version number in `luminoth/luminoth/__init__.py`.

Closes #53.