### PR TITLE
Don't use bare "except"

### DIFF
--- a/luminoth/utils/config.py
+++ b/luminoth/utils/config.py
@@ -86,12 +86,12 @@ def parse_config_value(value):
 
     try:
         return int(value)
-    except:
+    except ValueError:
         pass
 
     try:
         return float(value)
-    except:
+    except ValueError:
         pass
 
     return value


### PR DESCRIPTION
Bad practice (might catch `KeyboardInterrupt`, etc.). Better to catch `ValueError` in this case :)