### PR TITLE
Dataset not found handling

### DIFF
--- a/luminoth/datasets/tfrecord.py
+++ b/luminoth/datasets/tfrecord.py
@@ -1,6 +1,7 @@
 import os
 import tensorflow as tf
 
+from luminoth.tools.dataset.dataset import InvalidDataDirectory
 from .object_detection_dataset import ObjectDetectionDataset
 
 
@@ -49,12 +50,14 @@ class TFRecordDataset(ObjectDetectionDataset):
         TODO: Join filename, scaling_factor (and possible other fields) into a
         metadata.
         """
-
         # Find split file from which we are going to read.
         split_path = os.path.join(
             self._dataset_dir, '{}.tfrecords'.format(self._split)
         )
-
+        if not tf.gfile.Exists(split_path):
+            raise InvalidDataDirectory(
+                '"{}" does not exist.'.format(split_path)
+            )
         # String input producer allows for a variable number of files to read
         # from. We just know we have a single file.
         filename_queue = tf.train.string_input_producer(

--- a/luminoth/train.py
+++ b/luminoth/train.py
@@ -52,7 +52,8 @@ def run(model_type, dataset_type, config_file, override_params, target='',
             dataset = dataset_class(config)
             train_dataset = dataset()
         except InvalidDataDirectory as exc:
-            tf.logging.error("Error while reading dataset, {}".format(exc.message))
+            tf.logging.error(
+                'Error while reading dataset, {}'.format(exc.message))
             return
         train_image = train_dataset['image']
         train_filename = train_dataset['filename']

--- a/luminoth/train.py
+++ b/luminoth/train.py
@@ -9,6 +9,7 @@ from tensorflow.python import debug as tf_debug
 
 from luminoth.datasets.datasets import get_dataset
 from luminoth.models import get_model
+from luminoth.tools.dataset.dataset import InvalidDataDirectory
 from luminoth.utils.config import get_model_config
 from luminoth.utils.hooks import ImageVisHook
 from luminoth.utils.training import (
@@ -46,11 +47,13 @@ def run(model_type, dataset_type, config_file, override_params, target='',
     # See:
     # https://www.tensorflow.org/api_docs/python/tf/train/replica_device_setter
     with tf.device(tf.train.replica_device_setter(cluster=cluster_spec)):
-
-        dataset_class = get_dataset_fn(dataset_type)
-        dataset = dataset_class(config)
-        train_dataset = dataset()
-
+        try:
+            dataset_class = get_dataset_fn(dataset_type)
+            dataset = dataset_class(config)
+            train_dataset = dataset()
+        except InvalidDataDirectory as exc:
+            tf.logging.error("Error while reading dataset, {}".format(exc.message))
+            return
         train_image = train_dataset['image']
         train_filename = train_dataset['filename']
         train_bboxes = train_dataset['bboxes']


### PR DESCRIPTION
Added check to verify the existence of a file before adding it to the reader queue, in case a file doesn't exist, TFRecordDataset raises InvalidDataDirectory, train parses the error and logs it with tf.logging.