### PR TITLE
Test `clip_after_nms` and `filter_outside_anchors` options for RPN

### DIFF
--- a/luminoth/models/fasterrcnn/rpn_proposal.py
+++ b/luminoth/models/fasterrcnn/rpn_proposal.py
@@ -59,10 +59,13 @@ class RPNProposal(snt.AbstractModule):
                 nms_proposals_scores: A Tensor with the probability of being an
                     object for that proposal. Its shape should be
                     (total_nms_proposals, 1)
-                proposals: A Tensor with all the RPN proposals without any
-                    filtering.
-                scores: A Tensor with a score for each of the unfiltered RPN
+                proposals: A Tensor with all the valid RPN proposals.
+                scores: A Tensor with a score for each of the valid RPN
                     proposals.
+                proposals_raw: A Tensor with all the RPN proposals without any
+                    filtering.
+                scores_raw: A Tensor with a score for each of the unfiltered
+                    RPN proposals.
         """
         # Scores are extracted from the second scalar of the cls probability.
         # cls_probability is a softmax of (background, foreground).
@@ -94,10 +97,6 @@ class RPNProposal(snt.AbstractModule):
         # Decode boxes
         all_proposals = decode(all_anchors, rpn_bbox_pred)
 
-        if not self._clip_after_nms:
-            # Clip proposals to the image.
-            all_proposals = clip_boxes(all_proposals, im_shape)
-
         # Filter proposals with negative or zero area.
         (x_min, y_min, x_max, y_max) = tf.unstack(
             all_proposals, axis=1
@@ -118,6 +117,14 @@ class RPNProposal(snt.AbstractModule):
             all_proposals, proposal_filter,
             name='filter_invalid_proposals'
         )
+        if self._debug:
+            proposals_raw = tf.identity(proposals)
+            scores_raw = tf.identity(scores)
+
+        if not self._clip_after_nms:
+            # Clip proposals to the image.
+            proposals = clip_boxes(proposals, im_shape)
+
         filtered_proposals = tf.shape(scores)[0]
 
         tf.summary.scalar(
@@ -178,9 +185,11 @@ class RPNProposal(snt.AbstractModule):
             pred.update({
                 'proposals': proposals,
                 'scores': scores,
+                'proposals_raw': proposals_raw,
+                'scores_raw': scores_raw,
                 'top_k_proposals': top_k_proposals,
                 'top_k_scores': top_k_scores,
-                'all_proposals': all_proposals,
+                'all_proposals': all_proposals
             })
 
         return pred

--- a/luminoth/models/fasterrcnn/rpn_proposal_test.py
+++ b/luminoth/models/fasterrcnn/rpn_proposal_test.py
@@ -408,13 +408,13 @@ class RPNProposalTest(tf.test.TestCase):
             rpn_bbox_pred=rpn_bbox_pred)
         im_size = tf.placeholder(tf.float32, shape=(2,))
         proposals = tf.placeholder(
-            tf.float32, shape=(results_before['proposals_raw'].shape))
+            tf.float32, shape=(results_before['proposals_unclipped'].shape))
         clip_bboxes_tf = clip_boxes(proposals, im_size)
 
         with self.test_session() as sess:
             sess.run(tf.global_variables_initializer())
             clipped_proposals = sess.run(clip_bboxes_tf, feed_dict={
-                proposals: results_before['proposals_raw'],
+                proposals: results_before['proposals_unclipped'],
                 im_size: self.im_size
             })
 
@@ -443,20 +443,20 @@ class RPNProposalTest(tf.test.TestCase):
             rpn_bbox_pred=rpn_bbox_pred)
         im_size = tf.placeholder(tf.float32, shape=(2,))
         proposals = tf.placeholder(
-            tf.float32, shape=(results_after['proposals_raw'].shape))
+            tf.float32, shape=(results_after['proposals_unclipped'].shape))
         clip_bboxes_tf = clip_boxes(proposals, im_size)
 
         with self.test_session() as sess:
             sess.run(tf.global_variables_initializer())
             clipped_proposals = sess.run(clip_bboxes_tf, feed_dict={
-                proposals: results_after['proposals_raw'],
+                proposals: results_after['proposals_unclipped'],
                 im_size: self.im_size
             })
 
         # Check we don't clip proposals in the beginning of the function.
         self.assertAllEqual(
             results_after['proposals'],
-            results_after['proposals_raw']
+            results_after['proposals_unclipped']
         )
         # Check that the nms proposals are clipped
         no_negatives = np.maximum(results_after['nms_proposals'][:, 1:], 0)

--- a/luminoth/models/fasterrcnn/rpn_proposal_test.py
+++ b/luminoth/models/fasterrcnn/rpn_proposal_test.py
@@ -375,9 +375,7 @@ class RPNProposalTest(tf.test.TestCase):
         """
         Test clipping of proposals before and after NMS
         """
-        """
-        Before NMS
-        """
+        # Before NMS
         gt_boxes = np.array([
             [0, 0, 10, 12],
             [10, 10, 20, 22],
@@ -438,9 +436,7 @@ class RPNProposalTest(tf.test.TestCase):
         zeros = np.zeros(results_before['nms_proposals'][:, 1:].shape)
         self.assertAllEqual(top_max, zeros)
 
-        """
-        After NMS
-        """
+        # After NMS
         config['clip_after_nms'] = True
         results_after = self._run_rpn_proposal(
             all_anchors, rpn_cls_prob, config, gt_boxes=gt_boxes,


### PR DESCRIPTION
@ luminoth/models/fasterrcnn/rpn_proposal.py
- Added two debug variables to be able to get the proposals without any filter and changed the documentation to reflect that.
- Changed the order of the clipping of the proposals and the filtering of negative or zero area ones, this is made to be able of getting all the unclipped valid area proposals and also to avoid clipping invalid or zero area proposals.

@ luminoth/models/fasterrcnn/rpn_proposal_test.py
- Modified testClippingOfProposals to test if the clipping is made in the correct step and verifying the clipping was succesfull. Also changed the anchors given to the test to check different situations in which clipping is necessary.

- Added testFilterOutsideAnchors to check that all outside anchors are filtered when the config parameter is set to True, and its not applied when is set to False.
