### PR TITLE
Improve BaseNetwork, TruncatedBaseNetwork & fine tuning

### DIFF
--- a/luminoth/models/base/base_network.py
+++ b/luminoth/models/base/base_network.py
@@ -198,30 +198,30 @@ class BaseNetwork(snt.AbstractModule):
         """
         Returns a list of the variables that are trainable.
 
-        If a value for `finetune_from` is specified in the config, only the
+        If a value for `fine_tune_from` is specified in the config, only the
         variables starting from the first that contains this string in its name
         will be trainable. For example, specifying `vgg_16/fc6` for a VGG16
         will set only the variables in the fully connected layers to be
         trainable.
-        If `finetune_from` is None, then all the variables will be trainable.
+        If `fine_tune_from` is None, then all the variables will be trainable.
 
         Returns:
             trainable_variables: a list of `tf.Variable`.
         """
         all_variables = snt.get_variables_in_module(self)
 
-        finetune_from = self._config.get('finetune_from')
-        if finetune_from is None:
+        fine_tune_from = self._config.get('fine_tune_from')
+        if fine_tune_from is None:
             return all_variables
 
         # Get the index of the first trainable variable
         var_iter = enumerate(v.name for v in all_variables)
         try:
-            index = next(i for i, name in var_iter if finetune_from in name)
+            index = next(i for i, name in var_iter if fine_tune_from in name)
         except StopIteration:
             raise ValueError(
-                '"{}" is an invalid value of finetune_from for this '
-                'architecture.'.format(finetune_from)
+                '"{}" is an invalid value of fine_tune_from for this '
+                'architecture.'.format(fine_tune_from)
             )
 
         return all_variables[index:]

--- a/luminoth/models/base/base_network.py
+++ b/luminoth/models/base/base_network.py
@@ -27,6 +27,13 @@ VALID_ARCHITECTURES = set([
 
 
 class BaseNetwork(snt.AbstractModule):
+    """
+    Convolutional Neural Network used for image classification, whose
+    architecture can be any of the `VALID_ARCHITECTURES`.
+
+    This class wraps the `tf.slim` implementations of these models, with some
+    helpful additions.
+    """
 
     def __init__(self, config, name='base_network'):
         super(BaseNetwork, self).__init__(name=name)

--- a/luminoth/models/base/base_network.py
+++ b/luminoth/models/base/base_network.py
@@ -96,6 +96,16 @@ class BaseNetwork(snt.AbstractModule):
     def resnet_v2_type(self):
         return self._architecture.startswith('resnet_v2')
 
+    @property
+    def default_image_size(self):
+        # Usually 224, but depends on the architecture.
+        if self.vgg_type:
+            return vgg.vgg_16.default_image_size
+        if self.resnet_v1_type:
+            return resnet_v1.resnet_v1.default_image_size
+        if self.resnet_v2_type:
+            return resnet_v2.resnet_v2.default_image_size
+
     def _build(self, inputs, is_training=True):
         inputs = self.preprocess(inputs)
         with slim.arg_scope(self.arg_scope):

--- a/luminoth/models/base/base_network_test.py
+++ b/luminoth/models/base/base_network_test.py
@@ -63,7 +63,7 @@ class BaseNetworkTest(tf.test.TestCase):
 
         model = BaseNetwork(
             easydict.EasyDict(
-                {'architecture': 'vgg_16', 'finetune_from': 'conv5/conv5_3'}
+                {'architecture': 'vgg_16', 'fine_tune_from': 'conv5/conv5_3'}
             )
         )
         model(inputs)

--- a/luminoth/models/base/base_network_test.py
+++ b/luminoth/models/base/base_network_test.py
@@ -16,6 +16,13 @@ class BaseNetworkTest(tf.test.TestCase):
         })
         tf.reset_default_graph()
 
+    def testDefaultImageSize(self):
+        m = BaseNetwork(easydict.EasyDict({'architecture': 'vgg_16'}))
+        self.assertEquals(m.default_image_size, 224)
+
+        m = BaseNetwork(easydict.EasyDict({'architecture': 'resnet_v1_50'}))
+        self.assertEquals(m.default_image_size, 224)
+
     def testSubtractChannels(self):
         m = BaseNetwork(self.config)
         inputs = tf.placeholder(tf.float32, [1, 2, 2, 3])

--- a/luminoth/models/base/base_network_test.py
+++ b/luminoth/models/base/base_network_test.py
@@ -85,6 +85,18 @@ class BaseNetworkTest(tf.test.TestCase):
         #   fc8/biases:0
         self.assertEquals(len(model.get_trainable_vars()), 8)
 
+        #
+        # Check invalid fine_tune_from raises proper exception
+        #
+        model = BaseNetwork(
+            easydict.EasyDict(
+                {'architecture': 'vgg_16', 'fine_tune_from': 'conv5/conv99'}
+            )
+        )
+        model(inputs)
+        with self.assertRaises(ValueError):
+            model.get_trainable_vars()
+
 
 if __name__ == '__main__':
     tf.test.main()

--- a/luminoth/models/base/base_network_test.py
+++ b/luminoth/models/base/base_network_test.py
@@ -47,6 +47,37 @@ class BaseNetworkTest(tf.test.TestCase):
             tf.reset_default_graph()
             gc.collect(generation=2)
 
+    def testTrainableVariables(self):
+        inputs = tf.placeholder(tf.float32, [1, 224, 224, 3])
+
+        model = BaseNetwork(easydict.EasyDict({'architecture': 'vgg_16'}))
+        model(inputs)
+        # Variables in VGG16:
+        #   0 conv1/conv1_1/weights:0
+        #   1 conv1/conv1_1/biases:0
+        #   (...)
+        #   30 fc8/weights:0
+        #   31 fc8/biases:0
+
+        self.assertEquals(len(model.get_trainable_vars()), 32)
+
+        model = BaseNetwork(
+            easydict.EasyDict(
+                {'architecture': 'vgg_16', 'finetune_from': 'conv5/conv5_3'}
+            )
+        )
+        model(inputs)
+        # Variables from `conv5/conv5_3` to the end:
+        #   conv5/conv5_3/weights:0
+        #   conv5/conv5_3/biases:0
+        #   fc6/weights:0
+        #   fc6/biases:0
+        #   fc7/weights:0
+        #   fc7/biases:0
+        #   fc8/weights:0
+        #   fc8/biases:0
+        self.assertEquals(len(model.get_trainable_vars()), 8)
+
 
 if __name__ == '__main__':
     tf.test.main()

--- a/luminoth/models/base/truncated_base_network.py
+++ b/luminoth/models/base/truncated_base_network.py
@@ -51,7 +51,13 @@ class TruncatedBaseNetwork(BaseNetwork):
         pred = super(TruncatedBaseNetwork, self)._build(
             inputs, is_training=is_training
         )
-        return dict(pred['end_points'])[self._scope_endpoint]
+        try:
+            return dict(pred['end_points'])[self._scope_endpoint]
+        except KeyError:
+            raise ValueError(
+                '"{}" is an invalid value of endpoint for this '
+                'architecture.'.format(self._endpoint)
+            )
 
     def get_trainable_vars(self):
         """

--- a/luminoth/models/base/truncated_base_network.py
+++ b/luminoth/models/base/truncated_base_network.py
@@ -15,10 +15,13 @@ DEFAULT_ENDPOINTS = {
 
 class TruncatedBaseNetwork(BaseNetwork):
     """
-    TruncatedBaseNetwork is a normal classification CNN but instead of
-    returning a classification output it truncates it and returns the output
-    of middle convolutional layer.
+    Feature extractor for images using a regular CNN.
+
+    By using the notion of an "endpoint", we truncate a classification CNN at
+    a certain layer output, and return this partial feature map to be used as
+    a good image representation for other ML tasks.
     """
+
     def __init__(self, config, parent_name=None, name='truncated_base_network',
                  **kwargs):
         super(TruncatedBaseNetwork, self).__init__(config, name=name, **kwargs)
@@ -41,7 +44,9 @@ class TruncatedBaseNetwork(BaseNetwork):
 
         Returns:
             feature_map: A Tensor of shape
-                `(batch_size, feature_map_height feature_map_width, depth)`.
+                `(batch_size, feature_map_height, feature_map_width, depth)`.
+                The resulting dimensions depend on the CNN architecture and
+                endpoints used.
         """
         pred = super(TruncatedBaseNetwork, self)._build(
             inputs, is_training=is_training

--- a/luminoth/models/base/truncated_base_network.py
+++ b/luminoth/models/base/truncated_base_network.py
@@ -45,8 +45,8 @@ class TruncatedBaseNetwork(BaseNetwork):
         Returns:
             feature_map: A Tensor of shape
                 `(batch_size, feature_map_height, feature_map_width, depth)`.
-                The resulting dimensions depend on the CNN architecture and
-                endpoints used.
+                The resulting dimensions depend on the CNN architecture, the
+                endpoint used, and the dimensions of the input images.
         """
         pred = super(TruncatedBaseNetwork, self)._build(
             inputs, is_training=is_training

--- a/luminoth/models/base/truncated_base_network.py
+++ b/luminoth/models/base/truncated_base_network.py
@@ -47,3 +47,35 @@ class TruncatedBaseNetwork(BaseNetwork):
             inputs, is_training=is_training
         )
         return dict(pred['end_points'])[self._scope_endpoint]
+
+    def get_trainable_vars(self):
+        """
+        Returns a list of the variables that are trainable.
+
+        Returns:
+            trainable_variables: a list of `tf.Variable`.
+        """
+        all_trainable = super(TruncatedBaseNetwork, self).get_trainable_vars()
+
+        # Get the index of the last endpoint scope variable.
+        # For example, if the endpoint for ResNet-50 is set as
+        # "block4/unit_3/bottleneck_v1/conv2", then it will get 155,
+        # because the variables (with their indexes) are:
+        #   153 block4/unit_3/bottleneck_v1/conv2/weights:0
+        #   154 block4/unit_3/bottleneck_v1/conv2/BatchNorm/beta:0
+        #   155 block4/unit_3/bottleneck_v1/conv2/BatchNorm/gamma:0
+        var_iter = enumerate(v.name for v in all_trainable)
+        scope_var_index_iter = (
+            i for i, name in var_iter if self._endpoint in name
+        )
+        index = None
+        for index in scope_var_index_iter:
+            pass
+
+        if index is None:
+            raise ValueError(
+                '"{}" is an invalid value of endpoint for this '
+                'architecture.'.format(self._endpoint)
+            )
+
+        return all_trainable[:index + 1]

--- a/luminoth/models/base/truncated_base_network_test.py
+++ b/luminoth/models/base/truncated_base_network_test.py
@@ -106,6 +106,23 @@ class TruncatedBaseNetworkTest(tf.test.TestCase):
         #   146 block4/unit_2/bottleneck_v1/conv2/BatchNorm/gamma:0
         self.assertEquals(len(trainable_vars), 6)
 
+        #
+        # Check that we raise proper exception if fine_tune_from is after
+        # the chosen endpoint (there is nothing to fine-tune!)
+        #
+        model = TruncatedBaseNetwork(
+            easydict.EasyDict(
+                {
+                    'architecture': 'resnet_v1_50',
+                    'endpoint': 'block4/unit_2/bottleneck_v1/conv1',
+                    'fine_tune_from': 'block4/unit_2/bottleneck_v1/conv2',
+                }
+            )
+        )
+        model(inputs)
+        with self.assertRaises(ValueError):
+            model.get_trainable_vars()
+
 
 if __name__ == '__main__':
     tf.test.main()

--- a/luminoth/models/base/truncated_base_network_test.py
+++ b/luminoth/models/base/truncated_base_network_test.py
@@ -92,7 +92,7 @@ class TruncatedBaseNetworkTest(tf.test.TestCase):
             easydict.EasyDict({
                 'architecture': 'resnet_v1_50',
                 'endpoint': 'block4/unit_2/bottleneck_v1/conv2',
-                'finetune_from': 'block4/unit_2/bottleneck_v1/conv1',
+                'fine_tune_from': 'block4/unit_2/bottleneck_v1/conv1',
             })
         )
         model(inputs)

--- a/luminoth/models/fasterrcnn/base_config.yml
+++ b/luminoth/models/fasterrcnn/base_config.yml
@@ -119,7 +119,7 @@ model:
     # Starting point after which all the variables in the base network
     # will be trainable. If not specified, then all the variables in the
     # network will be trainable.
-    finetune_from:
+    fine_tune_from:
     arg_scope:
       # Regularization
       weight_decay: 0.0005

--- a/luminoth/models/fasterrcnn/base_config.yml
+++ b/luminoth/models/fasterrcnn/base_config.yml
@@ -116,8 +116,10 @@ model:
     download: True
     # Which endpoint layer to use as feature map for network
     endpoint:
-    # Is trainable, how many layers from the endpoint are we training
-    finetune_num_layers:
+    # Starting point after which all the variables in the base network
+    # will be trainable. If not specified, then all the variables in the
+    # network will be trainable.
+    finetune_from:
     arg_scope:
       # Regularization
       weight_decay: 0.0005

--- a/luminoth/models/fasterrcnn/fasterrcnn_test.py
+++ b/luminoth/models/fasterrcnn/fasterrcnn_test.py
@@ -38,7 +38,7 @@ class FasterRCNNNetworkTest(tf.test.TestCase):
                     'trainable': True,
                     'endpoint': 'conv5/conv5_1',
                     'download': False,
-                    'finetune_num_layers': 3,
+                    'finetune_from': 'conv4/conv4_2',
                     'arg_scope': {
                         'weight_decay': 0.0005,
                     }

--- a/luminoth/models/fasterrcnn/fasterrcnn_test.py
+++ b/luminoth/models/fasterrcnn/fasterrcnn_test.py
@@ -38,7 +38,7 @@ class FasterRCNNNetworkTest(tf.test.TestCase):
                     'trainable': True,
                     'endpoint': 'conv5/conv5_1',
                     'download': False,
-                    'finetune_from': 'conv4/conv4_2',
+                    'fine_tune_from': 'conv4/conv4_2',
                     'arg_scope': {
                         'weight_decay': 0.0005,
                     }


### PR DESCRIPTION
First step in being able to use this for classification.

* Remove concept of endpoint from `BaseNetwork`.
* Improve docstrings.
* Change way to do fine tuning (now it also works on ResNet or any architecture).
* Add `default_image_type` property (comes from TF slim).
* Add unit tests.