### PR TITLE
Fix tfrecord.py to allow handling greyscale images.

### DIFF
--- a/luminoth/datasets/tfrecord.py
+++ b/luminoth/datasets/tfrecord.py
@@ -78,7 +78,9 @@ class TFRecordDataset(ObjectDetectionDataset):
 
         # Decode and preprocess the example (crop, adjust mean and variance).
         # image_jpeg = tf.decode_raw(example['image_raw'], tf.string)
-        image_raw = tf.image.decode_jpeg(context_example['image_raw'])
+        image_raw = tf.image.decode_jpeg(
+            context_example['image_raw'], channels=3
+        )
         # tf.summary.image('image_raw', image_raw, max_outputs=20)
 
         # Do we need per_image_standardization? Do it depend on pretrained?


### PR DESCRIPTION
Currently, we were assuming all images were encoded as RGB.

We're now converting the image to RGB if necessary.