### PR TITLE
Adds TensorFlow 1.4 compatibility

### DIFF
--- a/luminoth/models/base/base_network_test.py
+++ b/luminoth/models/base/base_network_test.py
@@ -18,10 +18,10 @@ class BaseNetworkTest(tf.test.TestCase):
 
     def testDefaultImageSize(self):
         m = BaseNetwork(easydict.EasyDict({'architecture': 'vgg_16'}))
-        self.assertEquals(m.default_image_size, 224)
+        self.assertEqual(m.default_image_size, 224)
 
         m = BaseNetwork(easydict.EasyDict({'architecture': 'resnet_v1_50'}))
-        self.assertEquals(m.default_image_size, 224)
+        self.assertEqual(m.default_image_size, 224)
 
     def testSubtractChannels(self):
         m = BaseNetwork(self.config)
@@ -66,7 +66,7 @@ class BaseNetworkTest(tf.test.TestCase):
         #   30 fc8/weights:0
         #   31 fc8/biases:0
 
-        self.assertEquals(len(model.get_trainable_vars()), 32)
+        self.assertEqual(len(model.get_trainable_vars()), 32)
 
         model = BaseNetwork(
             easydict.EasyDict(
@@ -83,7 +83,7 @@ class BaseNetworkTest(tf.test.TestCase):
         #   fc7/biases:0
         #   fc8/weights:0
         #   fc8/biases:0
-        self.assertEquals(len(model.get_trainable_vars()), 8)
+        self.assertEqual(len(model.get_trainable_vars()), 8)
 
         #
         # Check invalid fine_tune_from raises proper exception

--- a/luminoth/models/base/truncated_base_network_test.py
+++ b/luminoth/models/base/truncated_base_network_test.py
@@ -81,8 +81,8 @@ class TruncatedBaseNetworkTest(tf.test.TestCase):
         #   159 logits/weights:0
         #   160 logits/biases:0
         trainable_vars = model.get_trainable_vars()
-        self.assertEquals(len(trainable_vars), 156)
-        self.assertEquals(
+        self.assertEqual(len(trainable_vars), 156)
+        self.assertEqual(
             trainable_vars[-1].name,
             'truncated_base_network/resnet_v1_50/' +
             'block4/unit_3/bottleneck_v1/conv2/BatchNorm/gamma:0'
@@ -104,7 +104,7 @@ class TruncatedBaseNetworkTest(tf.test.TestCase):
         #   144 block4/unit_2/bottleneck_v1/conv2/weights:0
         #   145 block4/unit_2/bottleneck_v1/conv2/BatchNorm/beta:0
         #   146 block4/unit_2/bottleneck_v1/conv2/BatchNorm/gamma:0
-        self.assertEquals(len(trainable_vars), 6)
+        self.assertEqual(len(trainable_vars), 6)
 
         #
         # Check that we raise proper exception if fine_tune_from is after

--- a/luminoth/models/base/truncated_base_network_test.py
+++ b/luminoth/models/base/truncated_base_network_test.py
@@ -66,26 +66,27 @@ class TruncatedBaseNetworkTest(tf.test.TestCase):
         )
         model(inputs)
         # Variables in ResNet-50:
+        # (the order of beta and gamma depends on the TensorFlow's version)
         #   0 conv1/weights:0
-        #   1 conv1/BatchNorm/beta:0
-        #   2 conv1/BatchNorm/gamma:0
+        #   1 conv1/BatchNorm/(beta|gamma):0
+        #   2 conv1/BatchNorm/(beta|gamma):0
         #   3 block1/unit_1/bottleneck_v1/shortcut/weights:0
         #   (...)
         #   153 block4/unit_3/bottleneck_v1/conv2/weights:0
-        #   154 block4/unit_3/bottleneck_v1/conv2/BatchNorm/beta:0
-        #   155 block4/unit_3/bottleneck_v1/conv2/BatchNorm/gamma:0
+        #   154 block4/unit_3/bottleneck_v1/conv2/BatchNorm/(beta|gamma):0
+        #   155 block4/unit_3/bottleneck_v1/conv2/BatchNorm/(beta|gamma):0
         #   --- endpoint ---
         #   156 block4/unit_3/bottleneck_v1/conv3/weights:0
-        #   157 block4/unit_3/bottleneck_v1/conv3/BatchNorm/beta:0
-        #   158 block4/unit_3/bottleneck_v1/conv3/BatchNorm/gamma:0
+        #   157 block4/unit_3/bottleneck_v1/conv3/BatchNorm/(beta|gamma):0
+        #   158 block4/unit_3/bottleneck_v1/conv3/BatchNorm/(beta|gamma):0
         #   159 logits/weights:0
         #   160 logits/biases:0
         trainable_vars = model.get_trainable_vars()
         self.assertEqual(len(trainable_vars), 156)
         self.assertEqual(
-            trainable_vars[-1].name,
+            trainable_vars[-3].name,
             'truncated_base_network/resnet_v1_50/' +
-            'block4/unit_3/bottleneck_v1/conv2/BatchNorm/gamma:0'
+            'block4/unit_3/bottleneck_v1/conv2/weights:0'
         )
 
         model = TruncatedBaseNetwork(

--- a/luminoth/models/fasterrcnn/fasterrcnn.py
+++ b/luminoth/models/fasterrcnn/fasterrcnn.py
@@ -69,9 +69,7 @@ class FasterRCNN(snt.AbstractModule):
         self._losses_collections = ['fastercnn_losses']
 
         # We want the pretrained model to be outside the FasterRCNN name scope.
-        self.base_network = TruncatedBaseNetwork(
-            config.model.base_network, parent_name=self.module_name
-        )
+        self.base_network = TruncatedBaseNetwork(config.model.base_network)
 
     def _build(self, image, gt_boxes=None, is_training=True):
         """

--- a/luminoth/models/fasterrcnn/rcnn_proposal.py
+++ b/luminoth/models/fasterrcnn/rcnn_proposal.py
@@ -35,7 +35,7 @@ class RCNNProposal(snt.AbstractModule):
         # Max number of object detections per class.
         self._class_max_detections = config.class_max_detections
         # NMS intersection over union threshold to be used for classes.
-        self._class_nms_threshold = config.class_nms_threshold
+        self._class_nms_threshold = float(config.class_nms_threshold)
         # Maximum number of detections to return.
         self._total_max_detections = config.total_max_detections
         # Threshold probability

--- a/luminoth/models/fasterrcnn/rpn_proposal.py
+++ b/luminoth/models/fasterrcnn/rpn_proposal.py
@@ -29,7 +29,7 @@ class RPNProposal(snt.AbstractModule):
         # bound.
         self._post_nms_top_n = config.post_nms_top_n
         # Threshold to use for NMS.
-        self._nms_threshold = config.nms_threshold
+        self._nms_threshold = float(config.nms_threshold)
         # Currently we do not filter out proposals by size.
         self._min_size = config.min_size
         self._filter_outside_anchors = config.filter_outside_anchors

--- a/luminoth/train.py
+++ b/luminoth/train.py
@@ -80,7 +80,7 @@ def run(custom_config, model_type, override_params, target='',
         prediction_dict = model(train_image, train_bboxes, is_training=True)
         total_loss = model.loss(prediction_dict)
 
-        global_step = tf.contrib.framework.get_or_create_global_step()
+        global_step = tf.train.get_or_create_global_step()
 
         optimizer = get_optimizer(config.train, global_step)
 


### PR DESCRIPTION
Tests now pass for TF 1.3 and 1.4.

- Fixes scope problems with slim models.
- Removes deprecated functions.

On a side note, `lumi --help` is finally "fast" again with Python3.6.