### PR TITLE
Evaluation using Google Cloud

### DIFF
--- a/luminoth/eval.py
+++ b/luminoth/eval.py
@@ -5,13 +5,9 @@ import tensorflow as tf
 import time
 
 from luminoth.datasets import get_dataset
-from luminoth.models import (
-    get_model
-)
-from luminoth.utils.config import (
-    get_model_config, load_config
-)
+from luminoth.models import get_model
 from luminoth.utils.bbox_overlap import bbox_overlap
+from luminoth.utils.config import get_model_config, load_config
 from luminoth.utils.image_vis import image_vis_summaries
 
 
@@ -547,3 +543,7 @@ def calculate_map(output_per_batch, num_classes, iou_threshold=0.5):
     mean_ap = np.mean(ap_per_class)
 
     return mean_ap, ap_per_class
+
+
+if __name__ == '__main__':
+    evaluate()

--- a/luminoth/eval.py
+++ b/luminoth/eval.py
@@ -313,7 +313,7 @@ def evaluate_once(writer, saver, ops, num_classes, checkpoint,
                 val_losses = sess.run(ops['losses'])
 
                 if image_vis is not None:
-                    filename = batch_fetched['filename'][:-4].decode('utf-8')
+                    filename = batch_fetched['filename'].decode('utf-8')
                     visualize_file = False
                     for gt_class in batch_gt_classes:
                         cls_files = files_to_visualize.get(

--- a/luminoth/tools/cloud/gcloud.py
+++ b/luminoth/tools/cloud/gcloud.py
@@ -17,6 +17,7 @@ from oauth2client import service_account
 
 from luminoth.models import get_model
 from luminoth.utils.config import get_model_config, load_config, dump_config
+from luminoth.utils.experiments import save_run
 
 
 SCALE_TIERS = ['BASIC', 'STANDARD_1', 'PREMIUM_1', 'BASIC_GPU', 'CUSTOM']
@@ -262,6 +263,9 @@ def train(job_id, service_account_json, bucket_name, region, config_files,
         click.echo('Job {} submitted successfully.'.format(job_id))
         click.echo('state = {}, createTime = {}'.format(
             res.get('state'), res.get('createTime')))
+
+        save_run(config, environment='gcloud', extra_config=job_spec)
+
     except Exception as err:
         click.echo(
             'There was an error creating the training job. '

--- a/luminoth/tools/cloud/gcloud.py
+++ b/luminoth/tools/cloud/gcloud.py
@@ -20,6 +20,7 @@ from luminoth.utils.config import get_model_config, load_config, dump_config
 from luminoth.utils.experiments import save_run
 
 
+RUNTIME_VERSION = '1.2'
 SCALE_TIERS = ['BASIC', 'STANDARD_1', 'PREMIUM_1', 'BASIC_GPU', 'CUSTOM']
 MACHINE_TYPES = [
     'standard', 'large_model', 'complex_model_s', 'complex_model_m',
@@ -238,7 +239,7 @@ def train(job_id, service_account_json, bucket_name, region, config_files,
         'args': args,
         'region': region,
         'jobDir': 'gs://{}/{}/'.format(bucket_name, base_path),
-        'runtimeVersion': '1.2'
+        'runtimeVersion': RUNTIME_VERSION
     }
 
     if scale_tier == 'CUSTOM':
@@ -327,7 +328,7 @@ def evaluate(job_id, service_account_json, bucket_name, dataset_split, region,
         'args': args,
         'region': region,
         'jobDir': job_dir,
-        'runtimeVersion': '1.2'
+        'runtimeVersion': RUNTIME_VERSION
     }
 
     evaluate_job_id = '{}_{}'.format(job_id, postfix)

--- a/luminoth/tools/cloud/gcloud.py
+++ b/luminoth/tools/cloud/gcloud.py
@@ -148,10 +148,18 @@ def validate_region(region, project_id, credentials):
     )
     try:
         regionrequest.execute()
-    except HttpError:
-        click.echo(
-            'Error: Couldn\'t find region "{}" for project "{}".'.format(
-                region, project_id))
+    except HttpError as err:
+        if err.resp.status == 404:
+            click.echo(
+                'Error: Couldn\'t find region "{}" for project "{}".'.format(
+                    region, project_id))
+        elif err.resp.status == 403:
+            click.echo('Error: Forbidden access to resources.')
+            click.echo(
+                'Make sure to enable "Cloud Compute API", "ML Engine" and '
+                '"Storage" for project.')
+        else:
+            click.echo('Unknown error: {}'.format(err.resp))
         sys.exit(1)
 
 

--- a/luminoth/train.py
+++ b/luminoth/train.py
@@ -8,17 +8,11 @@ import time
 from tensorflow.python import debug as tf_debug
 
 from luminoth.datasets import get_dataset
+from luminoth.models import get_model
 from luminoth.tools.dataset import InvalidDataDirectory
-from luminoth.models import (
-    get_model
-)
-from luminoth.utils.config import (
-    get_model_config, load_config
-)
+from luminoth.utils.config import get_model_config, load_config
 from luminoth.utils.hooks import ImageVisHook
-from luminoth.utils.training import (
-    get_optimizer, clip_gradients_by_norm
-)
+from luminoth.utils.training import get_optimizer, clip_gradients_by_norm
 
 
 def run(custom_config, model_type, override_params, target='',

--- a/luminoth/utils/config.py
+++ b/luminoth/utils/config.py
@@ -20,6 +20,18 @@ def load_config(filenames, warn_overwrite=True):
     return config
 
 
+def to_dict(config):
+    return {
+        k: (to_dict(v) if type(v) is EasyDict else v)
+        for k, v in config.items()
+    }
+
+
+def dump_config(config):
+    config = to_dict(config)
+    return yaml.dump(config, default_flow_style=False)
+
+
 def get_base_config(path, base_config_filename='base_config.yml'):
     config_path = os.path.join(os.path.dirname(path), base_config_filename)
     return load_config([config_path])

--- a/luminoth/utils/experiments.py
+++ b/luminoth/utils/experiments.py
@@ -1,0 +1,69 @@
+import datetime
+import json
+import os.path
+import subprocess
+import tensorflow as tf
+
+
+DEFAULT_BASE_PATH = os.path.expanduser('~/.luminoth')
+DEFAULT_FILENAME = 'runs.json'
+CURRENT_DIR = os.path.dirname(os.path.realpath(__file__))
+
+
+def get_diff():
+    try:
+        return subprocess.check_output(
+            ['git', 'diff'], cwd=CURRENT_DIR
+        ).strip().decode('utf-8')
+    except OSError:
+        return None
+
+
+def get_luminoth_version():
+    try:
+        return subprocess.check_output(
+            ['git', 'rev-parse', 'HEAD'], cwd=CURRENT_DIR
+        ).strip().decode('utf-8')
+    except OSError:
+        pass
+
+    try:
+        from luminoth import __version__ as lumi_version
+        return lumi_version
+    except ImportError:
+        pass
+
+
+def get_tensorflow_version():
+    try:
+        from tensorflow import __version__ as tf_version
+        return tf_version
+    except ImportError:
+        pass
+
+
+def save_run(config, environment=None, comment=None, extra_config=None,
+             base_path=DEFAULT_BASE_PATH, filename=DEFAULT_FILENAME):
+    if environment == 'cloud':
+        # We don't write runs inside Google Cloud, we run it before.
+        return
+
+    diff = get_diff()
+    lumi_version = get_luminoth_version()
+    tf_version = get_tensorflow_version()
+
+    experiment = {
+        'environment': environment,
+        'datetime': str(datetime.datetime.utcnow()) + 'Z',
+        'diff': diff,
+        'luminoth_version': lumi_version,
+        'tensorflow_version': tf_version,
+        'config': config,
+        'extra_config': extra_config,
+    }
+
+    file_path = os.path.join(base_path, filename)
+    tf.gfile.MakeDirs(base_path)
+
+    with tf.gfile.Open(file_path, 'a') as log:
+        log.write(json.dumps(experiment) + '\n')


### PR DESCRIPTION
- We now save the final configuration file in the bucket. This way we don't have to depend on having the same config files in the same order for running evaluation.
- This PR also adds a way to save "experiments" (which right know can't be disabled).

There still some rough edges. For example, evaluation tool doesn't know when to stop. Also, ideally we could run an evaluation node on the same job without "polluting" the job namespaces/dashboard.