### PR TITLE
Fix data augmentation for TF 1.2

### DIFF
--- a/luminoth/datasets/object_detection_dataset.py
+++ b/luminoth/datasets/object_detection_dataset.py
@@ -97,13 +97,18 @@ class ObjectDetectionDataset(snt.AbstractModule):
             prob = tf.to_float(aug_config.pop('prob', default_prob))
             apply_aug_strategy = tf.less(random_number, prob)
 
-            augmented = tf.cond(
+            augmented = aug_fn(image, bboxes, **aug_config)
+
+            image = tf.cond(
                 apply_aug_strategy,
-                lambda: aug_fn(image, bboxes, **aug_config),
-                lambda: {'image': image, 'bboxes': bboxes}
+                lambda: augmented['image'],
+                lambda: image
             )
-            image = augmented['image']
-            bboxes = augmented.get('bboxes')
+            bboxes = tf.cond(
+                apply_aug_strategy,
+                lambda: augmented['bboxes'],
+                lambda: bboxes
+            )
 
             applied_data_augmentation.append({aug_type: apply_aug_strategy})
 

--- a/luminoth/tools/cloud/gcloud.py
+++ b/luminoth/tools/cloud/gcloud.py
@@ -214,13 +214,10 @@ def train(job_id, service_account_json, bucket_name, region, config_files,
 
     args.extend([
         '-o', 'dataset.dir={}'.format(dataset),
-        '-o', 'dataset.data_augmentation=false'
     ])
 
     override_params = [
         'dataset.dir={}'.format(dataset),
-        # TODO: Turning off data_augmentation because of TF 1.2 limitations
-        'dataset.data_augmentation=false'
     ]
 
     custom_config = load_config(config_files)


### PR DESCRIPTION
Due to a bug in tensorflow 1.2 when returning dicts in `tf.cond`, we had had to disable data augmentation when training on google cloud.

This PR fixes the issue by not using dicts with `tf.cond` and reenables data augmentation for `lumi cloud gc train`.