### PR TITLE
Adds better RPN standalone support

### DIFF
--- a/luminoth/models/fasterrcnn/base_config.yml
+++ b/luminoth/models/fasterrcnn/base_config.yml
@@ -175,6 +175,8 @@ model:
       pre_nms_top_n: 12000
       # Total proposals to use after NMS (sorted by score)
       post_nms_top_n: 2000
+      # Option to apply NMS
+      apply_nms: True
       # NMS threshold used when removing "almost duplicates"
       nms_threshold: 0.6
       min_size: 0  # disable using 0
@@ -182,6 +184,8 @@ model:
       clip_after_nms: False
       # Filter proposals from anchors partially outside the image.
       filter_outside_anchors: False
+      # Minimum prob to be used as proposed object
+      min_prob_threshold: 0.0
 
     target:
       # Margin to crop proposals to close to the border

--- a/luminoth/models/fasterrcnn/fasterrcnn_test.py
+++ b/luminoth/models/fasterrcnn/fasterrcnn_test.py
@@ -104,6 +104,8 @@ class FasterRCNNNetworkTest(tf.test.TestCase):
                         'min_size': 0,
                         'clip_after_nms': False,
                         'filter_outside_anchors': False,
+                        'apply_nms': True,
+                        'min_prob_threshold': 0.0,
                     },
                     'target': {
                         'allowed_border': 0,
@@ -210,10 +212,10 @@ class FasterRCNNNetworkTest(tf.test.TestCase):
             np.ones((rpn_prediction['rpn_cls_prob'].shape[0]))
         )
 
-        # Check that every rpn proposal has 4 coordinates + 1 batch index
+        # Check that every rpn proposal has 4 coordinates
         self.assertEqual(
             rpn_prediction['proposals'].shape[1],
-            5
+            4
         )
 
         # Check we get rpn proposals clipped to the image.

--- a/luminoth/models/fasterrcnn/rcnn.py
+++ b/luminoth/models/fasterrcnn/rcnn.py
@@ -158,10 +158,7 @@ class RCNN(snt.AbstractModule):
                 'bbox_offsets': bbox_offsets_target,
             }
 
-        roi_prediction = self._roi_pool(
-            proposals, conv_feature_map,
-            im_shape
-        )
+        roi_prediction = self._roi_pool(proposals, conv_feature_map, im_shape)
 
         if self._debug:
             # Save raw roi prediction in debug mode.
@@ -224,10 +221,12 @@ class RCNN(snt.AbstractModule):
         # Calculate summaries for results
         variable_summaries(cls_prob, 'cls_prob', ['rcnn'])
         variable_summaries(bbox_offsets, 'bbox_offsets', ['rcnn'])
-        variable_summaries(pooled_features, 'pooled_features', ['rcnn'])
 
-        layer_summaries(self._classifier_layer, ['rcnn'])
-        layer_summaries(self._bbox_layer, ['rcnn'])
+        if self._debug:
+            variable_summaries(pooled_features, 'pooled_features', ['rcnn'])
+
+            layer_summaries(self._classifier_layer, ['rcnn'])
+            layer_summaries(self._bbox_layer, ['rcnn'])
 
         return prediction_dict
 

--- a/luminoth/models/fasterrcnn/rcnn_proposal.py
+++ b/luminoth/models/fasterrcnn/rcnn_proposal.py
@@ -45,7 +45,7 @@ class RCNNProposal(snt.AbstractModule):
         """
         Args:
             proposals: Tensor with the RPN proposals bounding boxes.
-                Shape (num_proposals, 5). Where num_proposals is less than
+                Shape (num_proposals, 4). Where num_proposals is less than
                 POST_NMS_TOP_N (We don't know exactly beforehand)
             bbox_pred: Tensor with the RCNN delta predictions for each proposal
                 for each class. Shape (num_proposals, 4 * num_classes)
@@ -65,11 +65,6 @@ class RCNNProposal(snt.AbstractModule):
                 Shape (final_num_proposals,)
 
         """
-
-        # remove batch_id from proposals
-        with tf.control_dependencies([tf.equal(tf.shape(proposals)[-1], 5)]):
-            proposals = proposals[:, 1:]
-
         # First we want get the most probable label for each proposal
         # We still have the background on idx 0 so we subtract 1 to the idxs.
         proposal_label = tf.argmax(cls_prob, axis=1) - 1

--- a/luminoth/models/fasterrcnn/rcnn_proposal_test.py
+++ b/luminoth/models/fasterrcnn/rcnn_proposal_test.py
@@ -11,8 +11,6 @@ class RCNNProposalTest(tf.test.TestCase):
         super(RCNNProposalTest, self).setUp()
 
         self._num_classes = 3
-        self._batch_number = 1
-
         self._image_shape = (900, 1440)
         self._config = EasyDict({
             'class_max_detections': 100,
@@ -53,7 +51,7 @@ class RCNNProposalTest(tf.test.TestCase):
 
         def bbox_encode(gt_boxes):
             return encode(
-                proposed_boxes[:, 1:], gt_boxes
+                proposed_boxes, gt_boxes
             )
         bbox_pred_tensor = tf.map_fn(
             bbox_encode, gt_boxes_per_class,
@@ -84,9 +82,9 @@ class RCNNProposalTest(tf.test.TestCase):
         """
 
         proposed_boxes = tf.constant([
-            (self._batch_number, 85, 500, 730, 590),
-            (self._batch_number, 50, 500, 70, 530),
-            (self._batch_number, 700, 570, 740, 598),
+            (85, 500, 730, 590),
+            (50, 500, 70, 530),
+            (700, 570, 740, 598),
         ])
         gt_boxes_per_class = tf.constant([
             [(101, 101, 201, 249)],
@@ -140,9 +138,9 @@ class RCNNProposalTest(tf.test.TestCase):
         # The first two boxes have a very high IoU between them. One of them
         # should be filtered by the NMS filter.
         proposed_boxes = tf.constant([
-            (self._batch_number, 85, 500, 730, 590),
-            (self._batch_number, 50, 500, 740, 570),
-            (self._batch_number, 700, 570, 740, 598),
+            (85, 500, 730, 590),
+            (50, 500, 740, 570),
+            (700, 570, 740, 598),
         ])
         gt_boxes_per_class = tf.constant([
             [(101, 101, 201, 249)],
@@ -177,9 +175,9 @@ class RCNNProposalTest(tf.test.TestCase):
         """
 
         proposed_boxes = tf.constant([
-            (self._batch_number, 1300, 800, 1435, 870),
-            (self._batch_number, 10, 1, 30, 7),
-            (self._batch_number, 2, 870, 80, 898),
+            (1300, 800, 1435, 870),
+            (10, 1, 30, 7),
+            (2, 870, 80, 898),
         ])
         gt_boxes_per_class = tf.constant([
             [(1320, 815, 1455, 912)],
@@ -225,9 +223,9 @@ class RCNNProposalTest(tf.test.TestCase):
         """
 
         proposed_boxes = tf.constant([
-            (self._batch_number, 200, 315, 400, 370),
-            (self._batch_number, 56, 0, 106, 4),
-            (self._batch_number, 15, 15, 20, 20),
+            (200, 315, 400, 370),
+            (56, 0, 106, 4),
+            (15, 15, 20, 20),
         ])
 
         gt_boxes_per_class = tf.constant([
@@ -279,15 +277,15 @@ class RCNNProposalTest(tf.test.TestCase):
         limits_model = RCNNProposal(limits_num_classes, limits_config)
 
         proposed_boxes = tf.constant([
-            (self._batch_number, 0, 0, 1, 1),  # class 0
-            (self._batch_number, 5, 5, 10, 10),  # class 1
-            (self._batch_number, 15, 15, 20, 20),  # class 1
-            (self._batch_number, 25, 25, 30, 30),  # class 0
-            (self._batch_number, 35, 35, 40, 40),
-            (self._batch_number, 38, 40, 65, 65),
-            (self._batch_number, 70, 50, 90, 90),  # class 0
-            (self._batch_number, 95, 95, 100, 100),
-            (self._batch_number, 105, 105, 110, 110),  # class 1
+            (0, 0, 1, 1),  # class 0
+            (5, 5, 10, 10),  # class 1
+            (15, 15, 20, 20),  # class 1
+            (25, 25, 30, 30),  # class 0
+            (35, 35, 40, 40),
+            (38, 40, 65, 65),
+            (70, 50, 90, 90),  # class 0
+            (95, 95, 100, 100),
+            (105, 105, 110, 110),  # class 1
         ])
         # All zeroes for our bbox_pred.
         bbox_pred = tf.constant([[0.] * limits_num_classes * 4] * 9)

--- a/luminoth/models/fasterrcnn/rcnn_target.py
+++ b/luminoth/models/fasterrcnn/rcnn_target.py
@@ -47,8 +47,7 @@ class RCNNTarget(snt.AbstractModule):
         """
         Args:
             proposals: A Tensor with the RPN bounding boxes proposals.
-                The shape of the Tensor is (num_proposals, 5), where the first
-                of the 5 values for each proposal is the batch number.
+                The shape of the Tensor is (num_proposals, 4).
             gt_boxes: A Tensor with the ground truth boxes for the image.
                 The shape of the Tensor is (num_gt, 5), having the truth label
                 as the last value for each box.
@@ -62,12 +61,6 @@ class RCNNTarget(snt.AbstractModule):
                 other proposal we return zeros.
                 The shape of the Tensor is (num_proposals, 4).
         """
-        # TODO: revise casts to int64 in tf.sparse_to_dense and tf.scatter_nd
-        # calls.
-
-        # Remove batch id from proposals.
-        proposals = proposals[:, 1:]
-
         overlaps = bbox_overlap_tf(proposals, gt_boxes[:, :4])
         # overlaps now contains (num_proposals, num_gt_boxes) with the IoU of
         # proposal P and ground truth box G in overlaps[P, G]

--- a/luminoth/models/fasterrcnn/rcnn_target_test.py
+++ b/luminoth/models/fasterrcnn/rcnn_target_test.py
@@ -15,7 +15,6 @@ class RCNNTargetTest(tf.test.TestCase):
         # these tests.
         self._num_classes = 5
         self._placeholder_label = 3.
-        self._batch_number = 1
 
         self._config = EasyDict({
             'foreground_threshold': 0.5,
@@ -41,7 +40,7 @@ class RCNNTargetTest(tf.test.TestCase):
             gt_boxes: a Tensor holding the ground truth boxes, with shape
                 (num_gt, 5). The last value is the class label.
             proposed_boxes: a Tensor holding the proposed boxes. Its shape is
-                (num_proposals, 5). The first value is the batch number.
+                (num_proposals, 4). The first value is the batch number.
 
         Returns:
             The tuple returned by RCNNTarget._build().
@@ -66,12 +65,12 @@ class RCNNTargetTest(tf.test.TestCase):
 
         proposed_boxes = tf.constant(
             [
-                (self._batch_number, 55, 75, 85, 105),  # Background
-                                                        # IoU ~0.1293
-                (self._batch_number, 25, 21, 85, 105),  # Foreground
-                                                        # IoU ~0.7934
-                (self._batch_number, 78, 98, 99, 135),  # Ignored
-                                                        # IoU ~0.0015
+                (55, 75, 85, 105),  # Background
+                                    # IoU ~0.1293
+                (25, 21, 85, 105),  # Foreground
+                                    # IoU ~0.7934
+                (78, 98, 99, 135),  # Ignored
+                                    # IoU ~0.0015
             ],
             dtype=tf.float32
         )
@@ -107,10 +106,10 @@ class RCNNTargetTest(tf.test.TestCase):
 
         proposed_boxes = tf.constant(
             [
-                (self._batch_number, 491, 70, 510, 92),  # IoU 0.0277
-                (self._batch_number, 400, 60, 450, 92),  # IoU 0.1147
-                (self._batch_number, 413, 40, 480, 77),  # IoU 0.4998: highest
-                (self._batch_number, 411, 40, 480, 77),  # IoU 0.4914
+                (491, 70, 510, 92),  # IoU 0.0277
+                (400, 60, 450, 92),  # IoU 0.1147
+                (413, 40, 480, 77),  # IoU 0.4998: highest
+                (411, 40, 480, 77),  # IoU 0.4914
             ],
             dtype=tf.float32
         )
@@ -145,9 +144,9 @@ class RCNNTargetTest(tf.test.TestCase):
 
         proposed_boxes = tf.constant(
             [
-                (self._batch_number, 0, 0, 39, 89),
-                (self._batch_number, 101, 106, 300, 450),
-                (self._batch_number, 340, 199, 410, 420),
+                (0, 0, 39, 89),
+                (101, 106, 300, 450),
+                (340, 199, 410, 420),
             ],
             dtype=tf.float32
         )
@@ -185,15 +184,15 @@ class RCNNTargetTest(tf.test.TestCase):
 
         proposed_boxes = tf.constant(
             [
-                (self._batch_number, 12, 70, 350, 540),  # noise
-                (self._batch_number, 190, 310, 240, 370),  # IoU: 0.4763
-                (self._batch_number, 197, 300, 252, 389),  # IoU: 0.9015
-                (self._batch_number, 196, 300, 252, 389),  # IoU: 0.8859
-                (self._batch_number, 197, 303, 252, 394),  # IoU: 0.8459
-                (self._batch_number, 180, 310, 235, 370),  # IoU: 0.3747
-                (self._batch_number, 0, 0, 400, 400),  # noise
-                (self._batch_number, 197, 302, 252, 389),  # IoU: 0.8832
-                (self._batch_number, 0, 0, 400, 400),  # noise
+                (12, 70, 350, 540),  # noise
+                (190, 310, 240, 370),  # IoU: 0.4763
+                (197, 300, 252, 389),  # IoU: 0.9015
+                (196, 300, 252, 389),  # IoU: 0.8859
+                (197, 303, 252, 394),  # IoU: 0.8459
+                (180, 310, 235, 370),  # IoU: 0.3747
+                (0, 0, 400, 400),  # noise
+                (197, 302, 252, 389),  # IoU: 0.8832
+                (0, 0, 400, 400),  # noise
             ],
             dtype=tf.float32
         )
@@ -248,17 +247,17 @@ class RCNNTargetTest(tf.test.TestCase):
 
         proposed_boxes = tf.constant(
             [
-                (self._batch_number, 12, 70, 350, 540),  # noise
-                (self._batch_number, 190, 310, 240, 370),  # IoU: 0.4763
-                (self._batch_number, 197, 300, 252, 389),  # IoU: 0.9015
-                (self._batch_number, 196, 300, 252, 389),  # IoU: 0.8859
-                (self._batch_number, 197, 303, 252, 394),  # IoU: 0.8459
-                (self._batch_number, 180, 310, 235, 370),  # IoU: 0.3747
-                (self._batch_number, 0, 0, 400, 400),  # noise
-                (self._batch_number, 197, 302, 252, 389),  # IoU: 0.8832
-                (self._batch_number, 180, 310, 235, 370),  # IoU: 0.3747
-                (self._batch_number, 180, 310, 235, 370),  # IoU: 0.3747
-                (self._batch_number, 0, 0, 400, 400),  # noise
+                (12, 70, 350, 540),  # noise
+                (190, 310, 240, 370),  # IoU: 0.4763
+                (197, 300, 252, 389),  # IoU: 0.9015
+                (196, 300, 252, 389),  # IoU: 0.8859
+                (197, 303, 252, 394),  # IoU: 0.8459
+                (180, 310, 235, 370),  # IoU: 0.3747
+                (0, 0, 400, 400),  # noise
+                (197, 302, 252, 389),  # IoU: 0.8832
+                (180, 310, 235, 370),  # IoU: 0.3747
+                (180, 310, 235, 370),  # IoU: 0.3747
+                (0, 0, 400, 400),  # noise
             ],
             dtype=tf.float32
         )
@@ -316,15 +315,15 @@ class RCNNTargetTest(tf.test.TestCase):
 
         proposed_boxes = tf.constant(
             [
-                (self._batch_number, 12, 70, 350, 540),  # noise
-                (self._batch_number, 190, 310, 240, 370),  # IoU: 0.4763
-                (self._batch_number, 197, 300, 252, 389),  # IoU: 0.9015
-                (self._batch_number, 196, 300, 252, 389),  # IoU: 0.8859
-                (self._batch_number, 197, 303, 252, 394),  # IoU: 0.8459
-                (self._batch_number, 180, 310, 235, 370),  # IoU: 0.3747
-                (self._batch_number, 0, 0, 400, 400),  # noise
-                (self._batch_number, 197, 302, 252, 389),  # IoU: 0.8832
-                (self._batch_number, 0, 0, 400, 400),  # noise
+                (12, 70, 350, 540),  # noise
+                (190, 310, 240, 370),  # IoU: 0.4763
+                (197, 300, 252, 389),  # IoU: 0.9015
+                (196, 300, 252, 389),  # IoU: 0.8859
+                (197, 303, 252, 394),  # IoU: 0.8459
+                (180, 310, 235, 370),  # IoU: 0.3747
+                (0, 0, 400, 400),  # noise
+                (197, 302, 252, 389),  # IoU: 0.8832
+                (0, 0, 400, 400),  # noise
             ],
             dtype=tf.float32
         )
@@ -372,15 +371,15 @@ class RCNNTargetTest(tf.test.TestCase):
         )
         proposed_boxes = tf.constant(
             [
-                (self._batch_number, 12, 70, 350, 540),  # noise
-                (self._batch_number, 190, 310, 240, 370),  # 2
-                (self._batch_number, 197, 300, 252, 389),  # 1
-                (self._batch_number, 196, 300, 252, 389),  # 1
-                (self._batch_number, 197, 303, 252, 394),  # 1
-                (self._batch_number, 180, 310, 235, 370),  # 2
-                (self._batch_number, 0, 0, 400, 400),  # 0
-                (self._batch_number, 197, 302, 252, 389),  # 1
-                (self._batch_number, 0, 0, 400, 400),  # 0
+                (12, 70, 350, 540),  # noise
+                (190, 310, 240, 370),  # 2
+                (197, 300, 252, 389),  # 1
+                (196, 300, 252, 389),  # 1
+                (197, 303, 252, 394),  # 1
+                (180, 310, 235, 370),  # 2
+                (0, 0, 400, 400),  # 0
+                (197, 302, 252, 389),  # 1
+                (0, 0, 400, 400),  # 0
             ],
             dtype=tf.float32
         )
@@ -428,13 +427,10 @@ class RCNNTargetTest(tf.test.TestCase):
             proposed_boxes = generate_gt_boxes(
                 total_proposals, im_shape
             )
-            proposed_boxes_w_batch = np.concatenate(
-                [[[self._batch_number]] * total_proposals, proposed_boxes],
-                axis=1
-            ).astype(np.float32)
             # Run RCNNTarget.
             (proposals_label, _) = self._run_rcnn_target(
-                self._shared_model, gt_boxes_w_label, proposed_boxes_w_batch
+                self._shared_model, gt_boxes_w_label,
+                proposed_boxes.astype(np.float32)
             )
             # Assertion
             foreground_number = proposals_label[proposals_label > 0].shape[0]
@@ -455,8 +451,8 @@ class RCNNTargetTest(tf.test.TestCase):
             [10, 10, 20, 20, 0]
         ], dtype=tf.float32)
 
-        proposed_boxes_backgrounds = [[1, 21, 21, 30, 30]] * 100
-        proposed_boxes_foreground = [[1, 11, 11, 19, 19]] * 100
+        proposed_boxes_backgrounds = [[21, 21, 30, 30]] * 100
+        proposed_boxes_foreground = [[11, 11, 19, 19]] * 100
 
         proposed_boxes = tf.constant(
             proposed_boxes_backgrounds + proposed_boxes_foreground,
@@ -506,8 +502,8 @@ class RCNNTargetTest(tf.test.TestCase):
         # Both proposals have the first gt_box as the best match, but one of
         # them should be assigned to the label of the second gt_box anyway.
         proposed_boxes = tf.constant([
-            [self._batch_number, 10, 10, 20, 20],
-            [self._batch_number, 12, 10, 20, 20],
+            [10, 10, 20, 20],
+            [12, 10, 20, 20],
         ], dtype=tf.float32)
 
         (proposals_label, _) = self._run_rcnn_target(

--- a/luminoth/models/fasterrcnn/rcnn_test.py
+++ b/luminoth/models/fasterrcnn/rcnn_test.py
@@ -68,7 +68,7 @@ class RCNNTest(tf.test.TestCase):
             tf.float32, shape=self._pretrained_feature_map_shape
         )
 
-        self._proposals_shape = (self._num_proposals, 5)
+        self._proposals_shape = (self._num_proposals, 4)
         self._proposals_ph = tf.placeholder(
             tf.float32, shape=self._proposals_shape
         )

--- a/luminoth/models/fasterrcnn/roi_pool.py
+++ b/luminoth/models/fasterrcnn/roi_pool.py
@@ -42,7 +42,7 @@ class ROIPoolingLayer(snt.AbstractModule):
         Args:
             roi_proposals: A Tensor with the bounding boxes of shape
                 (total_proposals, 5), where the values for each proposal are
-                (batch_num, x_min, y_min, x_max, y_max).
+                (x_min, y_min, x_max, y_max).
             im_shape: A Tensor with the shape of the image (height, width).
 
         Returns:
@@ -52,7 +52,7 @@ class ROIPoolingLayer(snt.AbstractModule):
         with tf.name_scope('get_bboxes'):
             im_shape = tf.cast(im_shape, tf.float32)
 
-            _, x1, y1, x2, y2 = tf.unstack(
+            x1, y1, x2, y2 = tf.unstack(
                 roi_proposals, axis=1
             )
 

--- a/luminoth/models/fasterrcnn/roi_pool_test.py
+++ b/luminoth/models/fasterrcnn/roi_pool_test.py
@@ -60,10 +60,10 @@ class ROIPoolingTest(tf.test.TestCase):
         result a 'roi_pool' of 2x2.
         """
         roi_proposals = np.array([
-            [0, 1, 1, 4, 4],  # Inside mat_A
-            [1, 6, 1, 9, 4],  # Inside mat_B
-            [2, 1, 6, 4, 9],  # Inside mat_C
-            [3, 6, 6, 9, 9],  # Inside mat_D
+            [1, 1, 4, 4],  # Inside mat_A
+            [6, 1, 9, 4],  # Inside mat_B
+            [1, 6, 4, 9],  # Inside mat_C
+            [6, 6, 9, 9],  # Inside mat_D
         ])
 
         results = self._run_roi_pooling(
@@ -117,10 +117,10 @@ class ROIPoolingTest(tf.test.TestCase):
         result a 'roi_pool' of 2x2. with
         """
         roi_proposals = np.array([
-            [0, 3, 1, 6, 4],  # Across mat_A and mat_B (half-half)
-            [1, 1, 3, 4, 7],  # Across mat_A and mat_C (half-half)
-            [2, 5, 3, 9, 7],  # Inside mat_B and mat_D (half-half)
-            [3, 3, 6, 6, 9],  # Inside mat_C and mat_D (half-half)
+            [3, 1, 6, 4],  # Across mat_A and mat_B (half-half)
+            [1, 3, 4, 7],  # Across mat_A and mat_C (half-half)
+            [5, 3, 9, 7],  # Inside mat_B and mat_D (half-half)
+            [3, 6, 6, 9],  # Inside mat_C and mat_D (half-half)
         ])
         a = self.multiplier_a
         b = self.multiplier_b
@@ -183,10 +183,10 @@ class ROIPoolingTest(tf.test.TestCase):
         """
 
         roi_proposals = np.array([
-            [0, 4, 1, 7, 4],  # Across mat_A and mat_B (1/4 - 3/4)
-            [1, 1, 4, 4, 8],  # Across mat_A and mat_C (1/4 - 3/4)
-            [2, 5, 4, 9, 8],  # Inside mat_B and mat_D (1/4 - 3/4)
-            [3, 4, 6, 7, 9],  # Inside mat_C and mat_D (1/4 - 3/4)
+            [4, 1, 7, 4],  # Across mat_A and mat_B (1/4 - 3/4)
+            [1, 4, 4, 8],  # Across mat_A and mat_C (1/4 - 3/4)
+            [5, 4, 9, 8],  # Inside mat_B and mat_D (1/4 - 3/4)
+            [4, 6, 7, 9],  # Inside mat_C and mat_D (1/4 - 3/4)
         ])
         a = self.multiplier_a
         b = self.multiplier_b

--- a/luminoth/models/fasterrcnn/rpn.py
+++ b/luminoth/models/fasterrcnn/rpn.py
@@ -173,8 +173,8 @@ class RPN(snt.AbstractModule):
         proposal_prediction = self._proposal(
             rpn_cls_prob, rpn_bbox_pred, all_anchors, im_shape)
 
-        prediction_dict['proposals'] = proposal_prediction['nms_proposals']
-        prediction_dict['scores'] = proposal_prediction['nms_proposals_scores']
+        prediction_dict['proposals'] = proposal_prediction['proposals']
+        prediction_dict['scores'] = proposal_prediction['scores']
 
         if self._debug:
             prediction_dict['proposal_prediction'] = proposal_prediction
@@ -192,24 +192,24 @@ class RPN(snt.AbstractModule):
 
             if self._debug:
                 prediction_dict['rpn_max_overlap'] = rpn_max_overlap
-
-            variable_summaries(rpn_bbox_target, 'rpn_bbox_target', ['rpn'])
+                variable_summaries(rpn_bbox_target, 'rpn_bbox_target', ['rpn'])
 
         # Variables summaries.
-        variable_summaries(
-            proposal_prediction['nms_proposals_scores'], 'rpn_scores', ['rpn'])
+        variable_summaries(prediction_dict['scores'], 'rpn_scores', ['rpn'])
         variable_summaries(rpn_cls_prob, 'rpn_cls_prob', ['rpn'])
         variable_summaries(rpn_bbox_pred, 'rpn_bbox_pred', ['rpn'])
-        variable_summaries(rpn_feature, 'rpn_feature', ['rpn'])
-        variable_summaries(
-            rpn_cls_score_original, 'rpn_cls_score_original', ['rpn'])
-        variable_summaries(
-            rpn_bbox_pred_original, 'rpn_bbox_pred_original', ['rpn'])
 
-        # Layer summaries.
-        layer_summaries(self._rpn, ['rpn'])
-        layer_summaries(self._rpn_cls, ['rpn'])
-        layer_summaries(self._rpn_bbox, ['rpn'])
+        if self._debug:
+            variable_summaries(rpn_feature, 'rpn_feature', ['rpn'])
+            variable_summaries(
+                rpn_cls_score_original, 'rpn_cls_score_original', ['rpn'])
+            variable_summaries(
+                rpn_bbox_pred_original, 'rpn_bbox_pred_original', ['rpn'])
+
+            # Layer summaries.
+            layer_summaries(self._rpn, ['rpn'])
+            layer_summaries(self._rpn_cls, ['rpn'])
+            layer_summaries(self._rpn_bbox, ['rpn'])
 
         return prediction_dict
 

--- a/luminoth/models/fasterrcnn/rpn_proposal.py
+++ b/luminoth/models/fasterrcnn/rpn_proposal.py
@@ -23,6 +23,7 @@ class RPNProposal(snt.AbstractModule):
         # Filtering config
         # Before applying NMS we filter the top N anchors.
         self._pre_nms_top_n = config.pre_nms_top_n
+        self._apply_nms = config.apply_nms
         # After applying NMS we filter the top M anchors.
         # It's important to understand that because of NMS, it is not certain
         # we will have this many output proposals. This is just the upper
@@ -34,6 +35,7 @@ class RPNProposal(snt.AbstractModule):
         self._min_size = config.min_size
         self._filter_outside_anchors = config.filter_outside_anchors
         self._clip_after_nms = config.clip_after_nms
+        self._min_prob_threshold = float(config.min_prob_threshold)
         self._debug = debug
 
     def _build(self, rpn_cls_prob, rpn_bbox_pred, all_anchors, im_shape):
@@ -53,28 +55,18 @@ class RPNProposal(snt.AbstractModule):
 
         Returns:
             prediction_dict with the following keys:
-                nms_proposals: A Tensor with the final selected proposed
+                proposals: A Tensor with the final selected proposed
                     bounding boxes. Its shape should be
-                    (total_nms_proposals, 4).
-                nms_proposals_scores: A Tensor with the probability of being an
+                    (total_proposals, 4).
+                scores: A Tensor with the probability of being an
                     object for that proposal. Its shape should be
-                    (total_nms_proposals, 1)
-                scores:  A Tensor with the scores of the proposals contained
-                    in `proposals` and `proposals_unclipped`.
-                proposals: A Tensor with all the valid area RPN proposals, this
-                    tensor is returned in debug mode and is used for
-                    testing, the proposals are clipped if `clip_after_nms` is
-                    set to False.
-                proposals_unclipped: Same as proposals but the proposals in
-                    this tensor are never clipped.
-                all_proposals: A Tensor with all the proposals, including the
-                    ones with zero or negative area.
+                    (total_proposals, 1)
         """
         # Scores are extracted from the second scalar of the cls probability.
         # cls_probability is a softmax of (background, foreground).
-        scores = rpn_cls_prob[:, 1]
+        all_scores = rpn_cls_prob[:, 1]
         # Force flatten the scores (it should be already be flatten).
-        scores = tf.reshape(scores, [-1])
+        all_scores = tf.reshape(all_scores, [-1])
 
         if self._filter_outside_anchors:
             with tf.name_scope('filter_outside_anchors'):
@@ -95,102 +87,109 @@ class RPNProposal(snt.AbstractModule):
                 all_anchors = tf.boolean_mask(
                     all_anchors, anchor_filter, name='filter_anchors')
                 rpn_bbox_pred = tf.boolean_mask(rpn_bbox_pred, anchor_filter)
-                scores = tf.boolean_mask(scores, anchor_filter)
+                all_scores = tf.boolean_mask(all_scores, anchor_filter)
 
         # Decode boxes
         all_proposals = decode(all_anchors, rpn_bbox_pred)
 
-        # Filter proposals with negative or zero area.
-        (x_min, y_min, x_max, y_max) = tf.unstack(
-            all_proposals, axis=1
+        # Filter proposals with less than threshold probability.
+        min_prob_filter = tf.greater_equal(
+            all_scores, self._min_prob_threshold
         )
-        proposal_filter = tf.greater(
+
+        # Filter proposals with negative or zero area.
+        (x_min, y_min, x_max, y_max) = tf.unstack(all_proposals, axis=1)
+        zero_area_filter = tf.greater(
             tf.maximum(x_max - x_min, 0.0) * tf.maximum(y_max - y_min, 0.0),
             0.0
         )
-        proposal_filter = tf.reshape(proposal_filter, [-1])
+        proposal_filter = tf.logical_and(zero_area_filter, min_prob_filter)
 
         # Filter proposals and scores.
-        total_proposals = tf.shape(scores)[0]
-        scores = tf.boolean_mask(
-            scores, proposal_filter,
-            name='filter_invalid_scores'
+        all_proposals_total = tf.shape(all_scores)[0]
+        unsorted_scores = tf.boolean_mask(
+            all_scores, proposal_filter,
+            name='filtered_scores'
         )
-        proposals = tf.boolean_mask(
+        unsorted_proposals = tf.boolean_mask(
             all_proposals, proposal_filter,
-            name='filter_invalid_proposals'
+            name='filtered_proposals'
         )
         if self._debug:
-            proposals_unclipped = tf.identity(proposals)
+            proposals_unclipped = tf.identity(unsorted_proposals)
 
         if not self._clip_after_nms:
             # Clip proposals to the image.
-            proposals = clip_boxes(proposals, im_shape)
+            unsorted_proposals = clip_boxes(unsorted_proposals, im_shape)
 
-        filtered_proposals = tf.shape(scores)[0]
+        filtered_proposals_total = tf.shape(unsorted_scores)[0]
 
         tf.summary.scalar(
             'valid_proposals_ratio',
             (
-                tf.cast(filtered_proposals, tf.float32) /
-                tf.cast(total_proposals, tf.float32)
+                tf.cast(filtered_proposals_total, tf.float32) /
+                tf.cast(all_proposals_total, tf.float32)
             ), ['rpn'])
 
         tf.summary.scalar(
-            'invalid_proposals', total_proposals - filtered_proposals, ['rpn'])
+            'invalid_proposals',
+            all_proposals_total - filtered_proposals_total, ['rpn'])
 
         # Get top `pre_nms_top_n` indices by sorting the proposals by score.
-        k = tf.minimum(self._pre_nms_top_n, tf.shape(scores)[0])
-        top_k = tf.nn.top_k(scores, k=k)
-        top_k_scores = top_k.values
+        k = tf.minimum(self._pre_nms_top_n, tf.shape(unsorted_scores)[0])
+        top_k = tf.nn.top_k(unsorted_scores, k=k)
 
-        top_k_proposals = tf.gather(proposals, top_k.indices)
-        # We reorder the proposals into TensorFlows bounding box order for
-        # `tf.image.non_max_supression` compatibility.
-        proposals_tf_order = change_order(top_k_proposals)
+        sorted_top_proposals = tf.gather(unsorted_proposals, top_k.indices)
+        sorted_top_scores = top_k.values
 
-        # We cut the pre_nms filter in pure TF version and go straight into
-        # NMS.
-        selected_indices = tf.image.non_max_suppression(
-            proposals_tf_order, tf.squeeze(top_k_scores), self._post_nms_top_n,
-            iou_threshold=self._nms_threshold
-        )
+        if self._apply_nms:
+            with tf.name_scope('nms'):
+                # We reorder the proposals into TensorFlows bounding box order
+                # for `tf.image.non_max_supression` compatibility.
+                proposals_tf_order = change_order(sorted_top_proposals)
+                # We cut the pre_nms filter in pure TF version and go straight
+                # into NMS.
+                selected_indices = tf.image.non_max_suppression(
+                    proposals_tf_order, tf.squeeze(sorted_top_scores),
+                    self._post_nms_top_n, iou_threshold=self._nms_threshold
+                )
 
-        # Selected_indices is a smaller tensor, we need to extract the
-        # proposals and scores using it.
-        nms_proposals = tf.gather(
-            proposals_tf_order, selected_indices, name='gather_nms_proposals'
-        )
-        nms_proposals_scores = tf.gather(
-            top_k_scores, selected_indices, name='gather_nms_proposals_scores'
-        )
+                # Selected_indices is a smaller tensor, we need to extract the
+                # proposals and scores using it.
+                nms_proposals_tf_order = tf.gather(
+                    proposals_tf_order, selected_indices,
+                    name='gather_nms_proposals'
+                )
 
-        # We switch back again to the regular bbox encoding.
-        nms_proposals = change_order(nms_proposals)
+                # We switch back again to the regular bbox encoding.
+                proposals = change_order(nms_proposals_tf_order)
+                scores = tf.gather(
+                    sorted_top_scores, selected_indices,
+                    name='gather_nms_proposals_scores'
+                )
+        else:
+            proposals = sorted_top_proposals
+            scores = sorted_top_scores
 
         if self._clip_after_nms:
             # Clip proposals to the image after NMS.
-            nms_proposals = clip_boxes(nms_proposals, im_shape)
-
-        # Adds batch number for consistency and multi image batch support.
-        batch_inds = tf.zeros(
-            (tf.shape(nms_proposals)[0], 1), dtype=tf.float32
-        )
-        nms_proposals = tf.concat([batch_inds, nms_proposals], axis=1)
+            proposals = clip_boxes(proposals, im_shape)
 
         pred = {
-            'nms_proposals': tf.stop_gradient(nms_proposals),
-            'nms_proposals_scores': tf.stop_gradient(nms_proposals_scores),
+            'proposals': proposals,
+            'scores': scores,
         }
 
         if self._debug:
             pred.update({
-                'proposals': proposals,
-                'scores': scores,
-                'proposals_unclipped': proposals_unclipped,
-                'top_k_proposals': top_k_proposals,
-                'top_k_scores': top_k_scores,
+                'sorted_top_scores': sorted_top_scores,
+                'sorted_top_proposals': sorted_top_proposals,
+                'unsorted_proposals': unsorted_proposals,
+                'unsorted_scores': unsorted_scores,
                 'all_proposals': all_proposals,
+                'all_scores': all_scores,
+                # proposals_unclipped has the unsorted_scores scores
+                'proposals_unclipped': proposals_unclipped,
             })
 
         return pred

--- a/luminoth/models/fasterrcnn/rpn_test.py
+++ b/luminoth/models/fasterrcnn/rpn_test.py
@@ -41,6 +41,8 @@ class RPNTest(tf.test.TestCase):
                 'min_size': 0,
                 'clip_after_nms': False,
                 'filter_outside_anchors': False,
+                'apply_nms': True,
+                'min_prob_threshold': 0.0,
             },
             'target': {
                 'allowed_border': 0,

--- a/luminoth/utils/checkpoint_downloader.py
+++ b/luminoth/utils/checkpoint_downloader.py
@@ -37,7 +37,6 @@ DEFAULT_PATH = get_default_path()
 
 
 def get_checkpoint_path(path=DEFAULT_PATH):
-    tf.logging.info('Creating folder "{}" to save checkpoints.'.format(path))
     # Expand user if path is relative to user home.
     path = os.path.expanduser(path)
 
@@ -45,7 +44,10 @@ def get_checkpoint_path(path=DEFAULT_PATH):
         # We don't need to create Google cloud storage "folders"
         path = os.path.abspath(path)
 
-    tf.gfile.MakeDirs(path)
+    if not tf.gfile.Exists(path):
+        tf.logging.info(
+            'Creating folder "{}" to save checkpoints.'.format(path))
+        tf.gfile.MakeDirs(path)
 
     return path
 

--- a/luminoth/utils/image_vis.py
+++ b/luminoth/utils/image_vis.py
@@ -449,8 +449,8 @@ def draw_top_proposals(pred_dict, image, min_score=0.8, max_display=20,
         'green = matches background in batch, red = ignored in batch)')
     proposal_prediction = pred_dict['rpn_prediction']['proposal_prediction']
     if top_k:
-        scores = proposal_prediction['top_k_scores']
-        proposals = proposal_prediction['top_k_proposals']
+        scores = proposal_prediction['sorted_top_scores']
+        proposals = proposal_prediction['sorted_top_proposals']
     else:
         scores = proposal_prediction['scores']
         proposals = proposal_prediction['proposals']
@@ -594,8 +594,6 @@ def draw_top_nms_proposals(pred_dict, image, min_score=0.8, draw_gt=False):
     logger.debug('Top NMS proposals (min_score = {})'.format(min_score))
     scores = pred_dict['rpn_prediction']['scores']
     proposals = pred_dict['rpn_prediction']['proposals']
-    # Remove batch id
-    proposals = proposals[:, 1:]
     top_scores_mask = scores > min_score
     scores = scores[top_scores_mask]
     proposals = proposals[top_scores_mask]
@@ -883,7 +881,7 @@ def draw_rcnn_cls_batch(pred_dict, image, foreground=True, background=True):
         '(GT labels are -1 from cls targets)')
     logger.debug('blue => GT, green => foreground, red => background')
 
-    proposals = pred_dict['rpn_prediction']['proposals'][:, 1:]
+    proposals = pred_dict['rpn_prediction']['proposals']
     cls_targets = pred_dict['classification_prediction']['target']['cls']
     bbox_offsets_targets = pred_dict[
         'classification_prediction']['target']['bbox_offsets']
@@ -929,7 +927,7 @@ def draw_rcnn_cls_batch_errors(pred_dict, image, foreground=True,
         'used for training classifier.'.format('worst' if worst else 'best'))
     logger.debug('blue => GT, green => foreground, red => background')
 
-    proposals = pred_dict['rpn_prediction']['proposals'][:, 1:]
+    proposals = pred_dict['rpn_prediction']['proposals']
     cls_targets = pred_dict['classification_prediction']['target']['cls']
     bbox_offsets_targets = pred_dict[
         'classification_prediction']['target']['bbox_offsets']
@@ -990,7 +988,7 @@ def draw_rcnn_reg_batch_errors(pred_dict, image):
         'blue => GT, green => foreground, '
         'r`regression_loss` - c`classification_loss`.')
 
-    proposals = pred_dict['rpn_prediction']['proposals'][:, 1:]
+    proposals = pred_dict['rpn_prediction']['proposals']
     cls_targets = pred_dict['classification_prediction']['target']['cls']
     bbox_offsets_targets = pred_dict[
         'classification_prediction']['target']['bbox_offsets']
@@ -1076,7 +1074,7 @@ def draw_rcnn_reg_batch_errors(pred_dict, image):
 
 
 def recalculate_objects(pred_dict, image):
-    proposals = pred_dict['rpn_prediction']['proposals'][:, 1:]
+    proposals = pred_dict['rpn_prediction']['proposals']
     proposals_prob = pred_dict['classification_prediction']['rcnn']['cls_prob']
     proposals_target = proposals_prob.argmax(axis=1) - 1
     bbox_offsets = pred_dict[
@@ -1158,7 +1156,7 @@ def draw_correct_rpn_proposals_anchors(pred_dict, image, top_k=5):
 
 
 def draw_rpn_correct_proposals(pred_dict, image):
-    proposals = pred_dict['rpn_prediction']['proposals'][:, 1:]
+    proposals = pred_dict['rpn_prediction']['proposals']
     gt_bboxes = pred_dict['gt_bboxes']
     gt_boxes = gt_bboxes[:, :4]
 
@@ -1182,7 +1180,7 @@ def draw_rcnn_input_proposals(pred_dict, image):
     logger.debug(
         'Display RPN proposals used in training classification. '
         'Top IoU with GT is displayed.')
-    proposals = pred_dict['rpn_prediction']['proposals'][:, 1:]
+    proposals = pred_dict['rpn_prediction']['proposals']
     gt_bboxes = pred_dict['gt_bboxes']
     gt_boxes = gt_bboxes[:, :4]
 


### PR DESCRIPTION
- Evaluation and web now run with_rcnn=False
- Better evaluation logs in debug
- Simpler rpn prediction dictionary
- Removes unused fake batch_id from RPN proposals
- It is now possible to disable NMS
- RPN Proposals can be filtered by score
- Some summaries are displayed only in debug mode