### PR TITLE
Fix small errors in prediction.

### DIFF
--- a/luminoth/train_test.py
+++ b/luminoth/train_test.py
@@ -45,7 +45,7 @@ class TrainTest(tf.test.TestCase):
         self.config = EasyDict({
             'model_type': 'fasterrcnn',
             'dataset_type': '',
-            'config_files': [],
+            'config_files': (),
             'override_params': [],
             'base_network': {
                 'download': False

--- a/luminoth/utils/config.py
+++ b/luminoth/utils/config.py
@@ -23,10 +23,11 @@ def get_config(config_files, override_params=None):
 
 
 def load_config_files(filename_or_filenames, warn_overwrite=True):
-    if not isinstance(filename_or_filenames, list):
-        filenames = [filename_or_filenames]
-    else:
+    if (isinstance(filename_or_filenames, list) or
+       isinstance(filename_or_filenames, tuple)):
         filenames = filename_or_filenames
+    else:
+        filenames = [filename_or_filenames]
 
     if len(filenames) <= 0:
         tf.logging.error("Tried to load 0 config files.")

--- a/luminoth/utils/predicting.py
+++ b/luminoth/utils/predicting.py
@@ -29,6 +29,8 @@ def get_predictions(image_paths, config_files):
         classes_file = os.path.join(config.dataset.dir, 'classes.json')
         if tf.gfile.Exists(classes_file):
             class_labels = json.load(tf.gfile.GFile(classes_file))
+        else:
+            class_labels = None
 
     session = None
     fetches = None


### PR DESCRIPTION
- Now can take a tuple of config files, because that's what click gives.
- We now allow a checkpoint directory to not have a classes.json file.
- change TrainTest to make sure we're testing compatibility with tuples.