### PR TITLE
Rename transform type in DATASETS.md from pascalvoc to pascal

### DIFF
--- a/docs/DATASETS.md
+++ b/docs/DATASETS.md
@@ -11,7 +11,7 @@ For this purpose, Luminoth provides the `lumi dataset transform` command, which 
 - [Pascal VOC2012](http://host.robots.ox.ac.uk:8080/pascal/VOC/voc2012/index.html)
 
 ```
-$ lumi dataset transform --type pascalvoc --data-dir ~/dataset/pascalvoc/ --output-dir ~/dataset/pascalvoc/tf/
+$ lumi dataset transform --type pascal --data-dir ~/dataset/pascal/ --output-dir ~/dataset/pascal/tf/
 ```
 
 - [ImageNet](http://image-net.org/download)


### PR DESCRIPTION
Making it consistent with how its named in READERS dict. The command
fails otherwise.