### PR TITLE
Fixes `git diff` command when git exists but is not in used (for logging training instances)

### DIFF
--- a/luminoth/utils/experiments.py
+++ b/luminoth/utils/experiments.py
@@ -15,7 +15,7 @@ def get_diff():
         return subprocess.check_output(
             ['git', 'diff'], cwd=CURRENT_DIR
         ).strip().decode('utf-8')
-    except OSError:
+    except:
         return None
 
 
@@ -24,7 +24,7 @@ def get_luminoth_version():
         return subprocess.check_output(
             ['git', 'rev-parse', 'HEAD'], cwd=CURRENT_DIR
         ).strip().decode('utf-8')
-    except OSError:
+    except:
         pass
 
     try:


### PR DESCRIPTION
Fixes #130