### PR TITLE
Update datasets docs.

### DIFF
--- a/docs/DATASETS.md
+++ b/docs/DATASETS.md
@@ -11,13 +11,19 @@ For this purpose, Luminoth provides the `lumi dataset transform` command, which 
 - [Pascal VOC2012](http://host.robots.ox.ac.uk:8080/pascal/VOC/voc2012/index.html)
 
 ```
-$ lumi dataset transform --type pascal --data-dir ~/dataset/pascal/ --output-dir ~/dataset/pascal/tf/
+$ lumi dataset transform --type pascal --data-dir ~/dataset/pascal/ --output-dir ~/dataset/pascal/tf/ --split train --split val
 ```
 
 - [ImageNet](http://image-net.org/download)
 
 ```
-$ lumi dataset transform --type imagenet --data-dir ~/dataset/imagenet/ --output-dir ~/dataset/imagenet/tf/
+$ lumi dataset transform --type imagenet --data-dir ~/dataset/imagenet/ --output-dir ~/dataset/imagenet/tf/ --split train --split val
+```
+
+- [COCO](http://cocodataset.org/#download)
+
+```
+$ lumi dataset transform --type coco --data-dir ~/dataset/coco/ --output-dir ~/dataset/coco/tf --split train --split val
 ```
 
 ## Limiting the dataset


### PR DESCRIPTION
Changed the documentation to reflect the fact that `--split` is now a required option for `lumi dataset transform`. Also, added COCO to the list of supported datasets.

We will need to change these docs again soon, but there have already been two issues (#127, #140) related to this so it seems like a good idea to update the docs now with respect to this.