### PR TITLE
Add video predict

### DIFF
--- a/luminoth/__init__.py
+++ b/luminoth/__init__.py
@@ -1,5 +1,5 @@
 from luminoth.cli import cli  # noqa
-from luminoth.utils.predicting import get_predictions  # noqa
+from luminoth.utils.predicting import network_gen  # noqa
 
 __version__ = '0.0.3dev0'
 

--- a/luminoth/__init__.py
+++ b/luminoth/__init__.py
@@ -1,5 +1,5 @@
 from luminoth.cli import cli  # noqa
-from luminoth.utils.predicting import network_gen  # noqa
+from luminoth.utils.predicting import PredictorNetwork  # noqa
 
 __version__ = '0.0.3dev0'
 

--- a/luminoth/predict.py
+++ b/luminoth/predict.py
@@ -140,8 +140,8 @@ def draw_bboxes_on_image(image, prediction, min_prob):
 
         # Chose colors for bbox, the 60 and 255 correspond to transparency
         color = get_color(label)
-        fill=tuple(color + [60])
-        outline=tuple(color + [255])
+        fill = tuple(color + [60])
+        outline = tuple(color + [255])
 
         draw.rectangle(bbox, fill=fill, outline=outline)
         label = str(label)
@@ -156,17 +156,20 @@ def get_color(class_label):
     """
     # We get these colors from the luminoth web client
     web_colors_hex = [
-    'ff0029', '377eb8', '66a61e', '984ea3', '00d2d5', 'ff7f00', 'af8d00',
-    '7f80cd', 'b3e900', 'c42e60', 'a65628', 'f781bf', '8dd3c7', 'bebada',
-    'fb8072', '80b1d3', 'fdb462', 'fccde5', 'bc80bd', 'ffed6f', 'c4eaff',
-    'cf8c00', '1b9e77', 'd95f02', 'e7298a', 'e6ab02', 'a6761d', '0097ff',
-    '00d067', '000000', '252525', '525252', '737373', '969696', 'bdbdbd',
-    'f43600', '4ba93b', '5779bb', '927acc', '97ee3f', 'bf3947', '9f5b00',
-    'f48758', '8caed6', 'f2b94f', 'eff26e', 'e43872', 'd9b100', '9d7a00',
-    '698cff', 'd9d9d9', '00d27e', 'd06800', '009f82', 'c49200', 'cbe8ff',
-    'fecddf', 'c27eb6', '8cd2ce', 'c4b8d9', 'f883b0', 'a49100', 'f48800',
-    '27d0df', 'a04a9b'
+        'ff0029', '377eb8', '66a61e', '984ea3', '00d2d5', 'ff7f00', 'af8d00',
+        '7f80cd', 'b3e900', 'c42e60', 'a65628', 'f781bf', '8dd3c7', 'bebada',
+        'fb8072', '80b1d3', 'fdb462', 'fccde5', 'bc80bd', 'ffed6f', 'c4eaff',
+        'cf8c00', '1b9e77', 'd95f02', 'e7298a', 'e6ab02', 'a6761d', '0097ff',
+        '00d067', '000000', '252525', '525252', '737373', '969696', 'bdbdbd',
+        'f43600', '4ba93b', '5779bb', '927acc', '97ee3f', 'bf3947', '9f5b00',
+        'f48758', '8caed6', 'f2b94f', 'eff26e', 'e43872', 'd9b100', '9d7a00',
+        '698cff', 'd9d9d9', '00d27e', 'd06800', '009f82', 'c49200', 'cbe8ff',
+        'fecddf', 'c27eb6', '8cd2ce', 'c4b8d9', 'f883b0', 'a49100', 'f48800',
+        '27d0df', 'a04a9b'
     ]
-    hex_to_rgb = lambda x: [int(x[i:i+2], 16) for i in (0, 2 ,4)]
     hex_color = web_colors_hex[hash(class_label) % len(web_colors_hex)]
-    return(hex_to_rgb(hex_color))
+    return hex_to_rgb(hex_color)
+
+
+def hex_to_rgb(x):
+    return [int(x[i:i + 2], 16) for i in (0, 2, 4)]

--- a/luminoth/predict.py
+++ b/luminoth/predict.py
@@ -90,7 +90,15 @@ def predict(path_or_dir, config_files, output_dir, save, min_prob, debug):
         elif is_video(file_path):
             # We'll hardcode the video ouput to mp4 for now
             save_path = os.path.splitext(save_path)[0] + '.mp4'
-            writer = skvideo.io.FFmpegWriter(save_path)
+            try:
+                writer = skvideo.io.FFmpegWriter(save_path)
+            except AssertionError as e:
+                # from IPython import embed; embed(display_banner=False)
+                tf.logging.error(e)
+                tf.logging.error(
+                    "Please install ffmpeg before making video predictions."
+                )
+                exit()
             num_of_frames = int(
                 skvideo.io.ffprobe(file_path)['video']['@nb_frames'])
             video_progress_bar = click.progressbar(

--- a/luminoth/tools/server/web.py
+++ b/luminoth/tools/server/web.py
@@ -15,7 +15,7 @@ app = Flask(__name__)
 def get_image():
     image = request.files.get('image')
     if not image:
-        return None
+        raise ValueError
 
     image = Image.open(image.stream).convert('RGB')
     return image
@@ -31,9 +31,12 @@ def predict(model_name):
     if request.method == 'GET':
         return jsonify(error='Use POST method to send image.'), 400
 
-    image_array = get_image()
-    if image_array is None:
-        return jsonify(error='Missing image.'), 400
+    try:
+        image_array = get_image()
+    except ValueError:
+        return jsonify(error='Missing image'), 400
+    except OSError:
+        return jsonify(error='Incompatible file type'), 400
 
     total_predictions = request.args.get('total')
     if total_predictions is not None:

--- a/luminoth/tools/server/web.py
+++ b/luminoth/tools/server/web.py
@@ -43,7 +43,9 @@ def predict(model_name):
         except ValueError:
             total_predictions = None
 
-    prediction = PREDICTOR_NETWORK.predict_image(image_array, total_predictions)
+    prediction = PREDICTOR_NETWORK.predict_image(
+        image_array, total_predictions
+    )
     return jsonify(prediction)
 
 

--- a/luminoth/tools/server/web.py
+++ b/luminoth/tools/server/web.py
@@ -7,12 +7,10 @@ from flask import Flask, jsonify, request, render_template
 from PIL import Image
 
 from luminoth.utils.config import get_config
-from luminoth.utils.predicting import get_prediction
+from luminoth.utils.predicting import PredictorNetwork
 
 
 app = Flask(__name__)
-
-LOADED_MODELS = {}
 
 
 def get_image():
@@ -20,7 +18,7 @@ def get_image():
     if not image:
         return None
 
-    image = Image.open(image.stream)
+    image = Image.open(image.stream).convert('RGB')
     return image
 
 
@@ -38,33 +36,15 @@ def predict(model_name):
     if image_array is None:
         return jsonify(error='Missing image.'), 400
 
-    total = request.args.get('total')
-    if total is not None:
+    total_predictions = request.args.get('total')
+    if total_predictions is not None:
         try:
-            total = int(total)
+            total_predictions = int(total_predictions)
         except ValueError:
-            total = None
+            total_predictions = None
 
-    config = app.config['config']
-    class_labels = app.config.get('class_labels')
-
-    if model_name in LOADED_MODELS:
-        image_tensor, fetches, session = LOADED_MODELS[model_name]
-        pred = get_prediction(
-            image_array, config, session=session, fetches=fetches,
-            image_tensor=image_tensor, class_labels=class_labels, total=total
-        )
-    else:
-        pred = get_prediction(
-            image_array, config, class_labels=class_labels, total=total,
-            return_tf_vars=True
-        )
-        LOADED_MODELS[model_name] = (
-            pred['image_tensor'], pred['fetches'], pred['session']
-        )
-
-        del pred['image_tensor'], pred['fetches'], pred['session']
-    return jsonify(pred)
+    prediction = PREDICTOR_NETWORK.predict_image(image_array, total_predictions)
+    return jsonify(prediction)
 
 
 @click.command(help='Start basic web application.')
@@ -79,7 +59,6 @@ def web(config_files, host, port, debug):
         tf.logging.set_verbosity(tf.logging.INFO)
 
     config = get_config(config_files)
-    app.config['config'] = config
 
     # Bounding boxes will be filtered by frontend (using slider), so we set
     # a low threshold.
@@ -89,7 +68,11 @@ def web(config_files, host, port, debug):
         # Gets the names of the classes
         classes_file = os.path.join(config.dataset.dir, 'classes.json')
         if tf.gfile.Exists(classes_file):
-            app.config['class_labels'] = json.load(
+            config['class_labels'] = json.load(
                 tf.gfile.GFile(classes_file))
+
+    # Initialize model
+    global PREDICTOR_NETWORK
+    PREDICTOR_NETWORK = PredictorNetwork(config_files)
 
     app.run(host=host, port=port, debug=debug)

--- a/luminoth/utils/predicting.py
+++ b/luminoth/utils/predicting.py
@@ -4,8 +4,6 @@ import os
 import tensorflow as tf
 import time
 
-from PIL import Image
-
 from luminoth.models import get_model
 from luminoth.datasets import get_dataset
 from luminoth.utils.config import get_config

--- a/luminoth/utils/predicting.py
+++ b/luminoth/utils/predicting.py
@@ -119,9 +119,9 @@ class PredictorNetwork(object):
         objects_labels_prob = objects_labels_prob.tolist()
 
         if total_predictions:
-            objects = objects[:self.total]
-            objects_labels = objects_labels[:self.total]
-            objects_labels_prob = objects_labels_prob[:self.total]
+            objects = objects[:total_predictions]
+            objects_labels = objects_labels[:total_predictions]
+            objects_labels_prob = objects_labels_prob[:total_predictions]
 
         return {
             'objects': objects,

--- a/luminoth/utils/predicting.py
+++ b/luminoth/utils/predicting.py
@@ -40,7 +40,9 @@ class PredictorNetwork(object):
         self.session = tf.Session(graph=graph)
 
         with graph.as_default():
-            self.image_placeholder = tf.placeholder(tf.float32, (None, None, 3))
+            self.image_placeholder = tf.placeholder(
+                tf.float32, (None, None, 3)
+            )
             image_tf, _, process_meta = dataset.preprocess(
                 self.image_placeholder
             )

--- a/luminoth/utils/predicting.py
+++ b/luminoth/utils/predicting.py
@@ -95,7 +95,7 @@ class PredictorNetwork(object):
             if config.train.debug:
                 self.fetches['_debug'] = pred_dict
 
-    def predict_image(self, image):
+    def predict_image(self, image, total_predictions=None):
         start_time = time.time()
         fetched = self.session.run(self.fetches, feed_dict={
             self.image_placeholder: np.array(image)
@@ -117,6 +117,11 @@ class PredictorNetwork(object):
 
         objects = objects.tolist()
         objects_labels_prob = objects_labels_prob.tolist()
+
+        if total_predictions:
+            objects = objects[:self.total]
+            objects_labels = objects_labels[:self.total]
+            objects_labels_prob = objects_labels_prob[:self.total]
 
         return {
             'objects': objects,

--- a/setup.py
+++ b/setup.py
@@ -47,6 +47,7 @@ INSTALL_REQUIRES = [
     'google-cloud-storage>=1.2.0',
     'Flask>=0.12',
     'six>=1.11',
+    'sk-video',
 ]
 TEST_REQUIRES = []
 


### PR DESCRIPTION
Makes the `predict` command accept videos. There is no change in the api, just select a video, a folder of videos, or a folder of videos and images, using the same command you'd use if they were just images.

Currently doesn't produce a json with the prediction, only creates a predicted video output. A decision has yet to be made in the team as to how said json should be formatted in the case of videos.