### PR TITLE
Provide support for checkpoint management and usage

### DIFF
--- a/luminoth/__init__.py
+++ b/luminoth/__init__.py
@@ -1,6 +1,3 @@
-from luminoth.cli import cli  # noqa
-from luminoth.utils.predicting import PredictorNetwork  # noqa
-
 __version__ = '0.0.4dev0'
 
 __title__ = 'Luminoth'
@@ -13,3 +10,7 @@ __email__ = 'luminoth@tryolabs.com'
 
 __license__ = 'BSD 3-Clause License'
 __copyright__ = 'Copyright (c) 2018 Tryolabs S.A.'
+
+# Import functions that are part of Luminoth's public interface.
+from luminoth.cli import cli  # noqa
+from luminoth.utils.predicting import PredictorNetwork  # noqa

--- a/luminoth/cli.py
+++ b/luminoth/cli.py
@@ -13,7 +13,7 @@ import click
 
 from luminoth.eval import eval
 from luminoth.predict import predict
-from luminoth.tools import cloud, dataset, server
+from luminoth.tools import checkpoint, cloud, dataset, server
 from luminoth.train import train
 
 
@@ -25,9 +25,10 @@ def cli():
     pass
 
 
+cli.add_command(checkpoint)
 cli.add_command(cloud)
 cli.add_command(dataset)
-cli.add_command(predict)
 cli.add_command(eval)
-cli.add_command(train)
+cli.add_command(predict)
 cli.add_command(server)
+cli.add_command(train)

--- a/luminoth/eval.py
+++ b/luminoth/eval.py
@@ -228,7 +228,7 @@ def get_checkpoints(run_dir, from_global_step=None, last_only=False):
     if not ckpt or not ckpt.all_model_checkpoint_paths:
         raise ValueError('Could not find checkpoint in {}.'.format(run_dir))
 
-    # TODO: Any other way to get the global_step?
+    # TODO: Any other way to get the global_step? (Same as in `checkpoints`.)
     checkpoints = sorted([
         {'global_step': int(path.split('-')[-1]), 'file': path}
         for path in ckpt.all_model_checkpoint_paths

--- a/luminoth/models/base/base_network.py
+++ b/luminoth/models/base/base_network.py
@@ -181,7 +181,7 @@ class BaseNetwork(snt.AbstractModule):
         if self._config.get('weights') is None:
             # Download the weights (or used cached) if not specified in the
             # config file.
-            # Weights are downloaded by default to the ~/.luminoth folder if
+            # Weights are downloaded by default to the $LUMI_HOME folder if
             # running locally, or to the job bucket if running in Google Cloud.
             self._config['weights'] = get_checkpoint_file(self._architecture)
 

--- a/luminoth/predict.py
+++ b/luminoth/predict.py
@@ -66,8 +66,11 @@ def predict(path_or_dir, config_files, checkpoint, override_params, output_dir,
     # Resolve the config to use and initialize the mdoel.
     if checkpoint:
         config = get_checkpoint_config(checkpoint)
-    else:
+    elif config_files:
         config = get_config(config_files)
+    else:
+        click.echo('You must specify either a checkpoint or a config file.')
+        exit()
 
     if override_params:
         config = override_config_params(config, override_params)

--- a/luminoth/predict.py
+++ b/luminoth/predict.py
@@ -23,13 +23,14 @@ def get_filetype(filename):
 
 @click.command(help='Obtain a model\'s predictions on an image or directory of images.')  # noqa
 @click.argument('path-or-dir')
-@click.option('config_files', '--config', '-c', required=True, multiple=True, help='Config to use.')  # noqa
+@click.option('config_files', '--config', '-c', multiple=True, help='Config to use.')  # noqa
+@click.option('--checkpoint', help='Checkpoint to use.')
 @click.option('--output-dir', help='Where to write output')
 @click.option('--save/--no-save', default=False, help='Save the image with the prediction of the model')  # noqa
 @click.option('--min-prob', default=0.5, type=float, help='When drawing, only draw bounding boxes with probability larger than.')  # noqa
 @click.option('--ignore-classes', default=None, multiple=True, help='Classes to ignore when predicting')  # noqa
 @click.option('--debug', is_flag=True, help='Set debug level logging.')
-def predict(path_or_dir, config_files, output_dir, save, min_prob,
+def predict(path_or_dir, config_files, checkpoint, output_dir, save, min_prob,
             ignore_classes, debug):
     if debug:
         tf.logging.set_verbosity(tf.logging.DEBUG)
@@ -60,7 +61,9 @@ def predict(path_or_dir, config_files, output_dir, save, min_prob,
         exit()
 
     # Initialize model
-    network = PredictorNetwork(config_files)
+    # TODO: Resolve config before. Validate config_files and checkpoint. Load
+    # checkpoint information (separate functions from tool).
+    network = PredictorNetwork(config_files, checkpoint)
 
     # Create output_dir if it doesn't exist
     if output_dir:

--- a/luminoth/tools/__init__.py
+++ b/luminoth/tools/__init__.py
@@ -1,3 +1,4 @@
+from .checkpoint import checkpoint  # noqa
 from .cloud import cloud  # noqa
 from .dataset import dataset  # noqa
 from .server import server  # noqa

--- a/luminoth/tools/checkpoint/__init__.py
+++ b/luminoth/tools/checkpoint/__init__.py
@@ -1,0 +1,331 @@
+import click
+import json
+import os
+import shutil
+import six
+import tarfile
+import tensorflow as tf
+import uuid
+
+from luminoth.utils.config import get_config
+
+
+# TODO: Create directories if needed.
+LUMINOTH_PATH = os.path.expanduser('~/.luminoth')
+CHECKPOINT_INDEX = 'checkpoints.json'
+CHECKPOINT_PATH = 'checkpoints'
+
+
+def get_checkpoint(db, id_or_alias):
+    """Returns checkpoint in `db` indicatedby `id_or_alias`."""
+    for cp in db['checkpoints']:
+        if cp['id'] == id_or_alias or cp['alias'] == id_or_alias:
+            return cp
+
+
+def get_checkpoint_path(checkpoint_id):
+    path = os.path.join(LUMINOTH_PATH, CHECKPOINT_PATH, checkpoint_id)
+    return path
+
+
+# TODO: Move handling of db file into another module, with specification.
+def read_checkpoint_db():
+    """Reads the checkpoints database file from disk."""
+    path = os.path.join(LUMINOTH_PATH, CHECKPOINT_INDEX)
+    if not os.path.exists(path):
+        return {'checkpoints': []}
+
+    with open(path) as f:
+        index = json.load(f)
+
+    return index
+
+
+def save_checkpoint_db(checkpoints):
+    """Overwrites the database file in disk with `checkpoints`."""
+    # TODO: Merge instead? Careful with deletions.
+    path = os.path.join(LUMINOTH_PATH, CHECKPOINT_INDEX)
+    with open(path, 'w') as f:
+        json.dump(checkpoints, f)
+
+
+@click.command(help='List available checkpoints.')
+def list():
+    db = read_checkpoint_db()
+
+    if not db['checkpoints']:
+        click.echo('No checkpoints available.')
+        return
+
+    template = '{:>12} | {:>7} | {:>10} | {:>40} | {:>13}'
+
+    header = template.format('id', 'dataset', 'model', 'description', 'status')
+    click.echo(header)
+    click.echo('=' * len(header))
+
+    for checkpoint in db['checkpoints']:
+        line = template.format(
+            checkpoint['id'],
+            checkpoint['dataset']['name'],
+            checkpoint['model']['name'],
+            checkpoint['description'],
+            checkpoint['status'],
+        )
+        click.echo(line)
+
+
+@click.command(help='Display detailed information on checkpoint.')
+@click.argument('id_or_alias')
+def info(id_or_alias):
+    db = read_checkpoint_db()
+
+    checkpoint = get_checkpoint(db, id_or_alias)
+    if not checkpoint:
+        click.echo(
+            "Checkpoint '{}' not found in index.".format(id_or_alias)
+        )
+        return
+
+    click.echo('{} - {}'.format(checkpoint['id'], checkpoint['name']))
+    click.echo('Description: {}'.format(checkpoint['description']))
+    # TODO: Rest of the info.
+
+
+@click.command(help='Create a checkpoint from a configuration file.')
+@click.argument('config_files', nargs=-1)
+@click.option(
+    'override_params', '--override', '-o', multiple=True,
+    help='Override model config params.'
+)
+@click.option('--alias', help="Specify the checkpoint's alias.")
+def create(config_files, override_params, alias):
+    click.echo('Creating checkpoint for given configuration...')
+    # TODO: Validate alias and the rest of the commands.
+
+    # Get and build the configuration file for the model.
+    config = get_config(config_files, override_params=override_params)
+
+    # Retrieve the files for the last checkpoint available.
+    run_dir = os.path.join(config.train.job_dir, config.train.run_name)
+    ckpt = tf.train.get_checkpoint_state(run_dir)
+    if not ckpt or not ckpt.all_model_checkpoint_paths:
+        click.echo("Couldn't find checkpoint in '{}'.".format(run_dir))
+        return
+
+    # TODO: Can we count on them being sorted and not do this?
+    last_checkpoint = sorted([
+        {'global_step': int(path.split('-')[-1]), 'file': path}
+        for path in ckpt.all_model_checkpoint_paths
+    ], key=lambda c: c['global_step'])[-1]['file']
+
+    checkpoint_prefix = os.path.basename(last_checkpoint)
+    checkpoint_paths = [
+        os.path.join(run_dir, file)
+        for file in os.listdir(run_dir)
+        if file.startswith(checkpoint_prefix)
+    ]
+
+    # Find the `classes.json` file.
+    classes_path = os.path.join(config.dataset.dir, 'classes.json')
+    if not os.path.exists(classes_path):
+        classes_path = None
+
+    # Create an checkpoint_id to identify the checkpoint.
+    checkpoint_id = str(uuid.uuid4()).replace('-', '')[:12]
+
+    # Update the directory paths for the configuration file. Since it's going
+    # to be packed into a single tar file, we set them to the current directoy.
+    # TODO: Just empty them and hard-code when loading? Other way of doing?
+    config.dataset.dir = '.'
+    config.train.job_dir = '.'
+    config.train.run_name = checkpoint_id
+
+    # Create the directory that will contain the model.
+    # TODO: Abstract into function for handling filesystem-related stuff.
+    path = os.path.join(LUMINOTH_PATH, CHECKPOINT_PATH, checkpoint_id)
+    os.makedirs(path, exist_ok=True)
+
+    with open(os.path.join(path, 'config.yml'), 'w') as f:
+        json.dump(config, f)
+
+    # Add the checkpoint files.
+    for checkpoint_path in checkpoint_paths:
+        shutil.copy2(checkpoint_path, path)
+
+    # Add `checkpoint` file to indicate where the checkpoint is located. We
+    # need to create it manually instead of just copying as it may contain
+    # absolute paths.
+    with open(os.path.join(path, 'checkpoint'), 'w') as f:
+        f.write(
+            """
+            model_checkpoint_path: "{0}"
+            all_model_checkpoint_paths: "{0}"
+            """.format(checkpoint_prefix)
+        )
+
+    # Add the `classes.json` file.
+    if classes_path:
+        shutil.copy2(classes_path, path)
+
+    # Store the new checkpoint into the checkpoint index.
+    # TODO: Collect metadata correctly.
+    metadata = {
+        'id': checkpoint_id,
+        'status': 'LOCAL',
+        'description': 'Description',
+        'dataset': {'name': 'COCO'},
+        'model': {'name': config.model.type},
+    }
+
+    if alias:
+        metadata['alias'] = alias
+
+    db = read_checkpoint_db()
+    db['checkpoints'].append(metadata)
+    save_checkpoint_db(db)
+
+    click.echo('Checkpoint {} created successfully.'.format(checkpoint_id))
+
+
+@click.command(help='Remove a checkpoint from the index and delete its files.')
+@click.argument('id_or_alias')
+def delete(id_or_alias):
+    db = read_checkpoint_db()
+    checkpoint = get_checkpoint(db, id_or_alias)
+    if not checkpoint:
+        click.echo(
+            "Checkpoint '{}' not found in index.".format(id_or_alias)
+        )
+        return
+
+    # Remove entry from index.
+    db['checkpoints'] = [
+        cp for cp in db['checkpoints']
+        if not cp['id'] == checkpoint['id']
+    ]
+    save_checkpoint_db(db)
+
+    # Delete tar file associated to checkpoint.
+    # TODO: Don't calculate this everytime, centralized way to access.
+    path = os.path.join(LUMINOTH_PATH, CHECKPOINT_PATH, checkpoint['id'])
+    try:
+        shutil.rmtree(path)
+    except OSError:
+        # The tar is not present, warn the user just in case.
+        click.echo(
+            'Skipping files deletion; not present in {}.'.format(path)
+        )
+
+    click.echo('Checkpoint {} deleted successfully.'.format(checkpoint['id']))
+
+
+@click.command(help='Export a checkpoint to a tar file for easy sharing.')
+@click.argument('id_or_alias')
+@click.option('--output', default='.', help="Specify the output location.")
+def export(id_or_alias, output):
+    db = read_checkpoint_db()
+    checkpoint = get_checkpoint(db, id_or_alias)
+    if not checkpoint:
+        click.echo(
+            "Checkpoint '{}' not found in index.".format(id_or_alias)
+        )
+        return
+
+    # Create the tar that will contain the checkpoint.
+    tar_path = os.path.join(
+        os.path.abspath(output),
+        '{}.tar'.format(checkpoint['id'])
+    )
+    # TODO: Same as above, no hard-coding.
+    checkpoint_path = os.path.join(
+        LUMINOTH_PATH, CHECKPOINT_PATH, checkpoint['id']
+    )
+    with tarfile.open(tar_path, 'w') as f:
+        # Add the config file. Dump the dict into a BytesIO, go to the
+        # beginning of the file and pass it as a file to the tar.
+        # TODO: Python 2 compatibility.
+        metadata_file = six.BytesIO()
+        metadata_file.write(json.dumps(checkpoint).encode('utf-8'))
+        metadata_file.seek(0)
+
+        tarinfo = tarfile.TarInfo(name='metadata.json')
+        tarinfo.size = len(metadata_file.getvalue())
+        f.addfile(tarinfo=tarinfo, fileobj=metadata_file)
+
+        # Add the files present in the checkpoint's directory.
+        for filename in os.listdir(checkpoint_path):
+            path = os.path.join(checkpoint_path, filename)
+            f.add(path, filename)
+
+    click.echo('Checkpoint {} exported successfully.'.format(checkpoint['id']))
+
+
+@click.command(help='Import a checkpoint tar into the local index.')
+@click.argument('path')
+def import_(path):
+    # Load the checkpoint metadata first.
+    try:
+        with tarfile.open(path) as f:
+            metadata = json.load(f.extractfile('metadata.json'))
+    except tarfile.ReadError:
+        click.echo("Invalid file. Is it an exported checkpoint?")
+        return
+    except KeyError:
+        click.echo(
+            "Tar file doesn't contain `metadata.json`. "
+            "Is it an exported checkpoint?"
+        )
+        return
+
+    # Check if checkpoint isn't present already.
+    # TODO: Check for alias conflict too. Flag to overwrite?
+    db = read_checkpoint_db()
+    checkpoint = get_checkpoint(db, metadata['id'])
+    if checkpoint:
+        click.echo(
+            "Checkpoint '{}' already found in index.".format(metadata['id'])
+        )
+        return
+
+    # Check if the output directory doesn't exist already.
+    # TODO: Path management.
+    output_path = os.path.join(LUMINOTH_PATH, CHECKPOINT_PATH, metadata['id'])
+    if os.path.exists(output_path):
+        click.echo(
+            "Checkpoint directory '{}' for checkpoint_id '{}' already exists. "
+            "Try issuing a `lumi checkpoint delete` or delete the directory "
+            "manually.".format(output_path, metadata['id'])
+        )
+        return
+
+    # Extract all the files except `metadata.json` into the checkpoint
+    # directory.
+    with tarfile.open(path) as f:
+        members = [m for m in f.getmembers() if m.name != 'metadata.json']
+        f.extractall(output_path, members)
+
+    # Store metadata into the checkpoint index.
+    db['checkpoints'].append(metadata)
+    save_checkpoint_db(db)
+
+    click.echo('Checkpoint {} imported successfully.'.format(metadata['id']))
+
+
+@click.command(help='Download checkpoint')
+@click.argument('id_or_alias')
+def download(id_or_alias):
+    click.echo('Not implemented yet.')
+
+
+@click.group(help='Groups of commands to manage checkpoints')
+def checkpoint():
+    pass
+
+
+checkpoint.add_command(create)
+checkpoint.add_command(delete)
+checkpoint.add_command(download)
+checkpoint.add_command(export)
+checkpoint.add_command(import_, name='import')
+checkpoint.add_command(info)
+checkpoint.add_command(list)

--- a/luminoth/tools/checkpoint/__init__.py
+++ b/luminoth/tools/checkpoint/__init__.py
@@ -30,7 +30,7 @@ def get_checkpoints_directory():
     # Checkpoint directory, `$LUMI_HOME/checkpoints/`. Create if not present.
     path = os.path.join(get_luminoth_home(), CHECKPOINT_PATH)
     if not os.path.exists(path):
-        os.makedirs(path, exist_ok=True)
+        tf.gfile.MakeDirs(path)
     return path
 
 
@@ -465,7 +465,7 @@ def create(config_files, override_params, entries):
 
     # Create the directory that will contain the model.
     path = get_checkpoint_path(checkpoint_id)
-    os.makedirs(path, exist_ok=True)
+    tf.gfile.MakeDirs(path)
 
     with open(os.path.join(path, 'config.yml'), 'w') as f:
         json.dump(config, f)

--- a/luminoth/tools/checkpoint/__init__.py
+++ b/luminoth/tools/checkpoint/__init__.py
@@ -97,8 +97,22 @@ def merge_index(local_index, remote_index):
 
 
 def get_checkpoint(db, id_or_alias):
-    """Returns checkpoint in `db` indicatedby `id_or_alias`."""
-    for cp in db['checkpoints']:
+    """Returns checkpoint in `db` indicated by `id_or_alias`.
+
+    First tries to match an ID, then an alias. For the case of repeated
+    aliases, will match first match local checkpoints and then remotes. In both
+    cases, matching will be newest first.
+    """
+    # TODO: Warn when there's a repeated alias.
+    # TODO: Once we track added date, order by that.
+    locals = [c for c in db['checkpoints'] if c['source'] == 'local']
+    remotes = [c for c in db['checkpoints'] if c['source'] == 'remote']
+
+    for cp in locals:
+        if cp['id'] == id_or_alias or cp['alias'] == id_or_alias:
+            return cp
+
+    for cp in remotes:
         if cp['id'] == id_or_alias or cp['alias'] == id_or_alias:
             return cp
 

--- a/luminoth/tools/checkpoint/__init__.py
+++ b/luminoth/tools/checkpoint/__init__.py
@@ -82,7 +82,7 @@ def merge_index(local_index, remote_index):
         seen_ids.add(checkpoint['id'])
         local = remotes_in_local.get(checkpoint['id'])
         if local:
-            # Checkpoint is in local index. Overwrite the all the fields.
+            # Checkpoint is in local index. Overwrite all the fields.
             local.update(**checkpoint)
         elif not local:
             # Checkpoint not found, it's an addition. Transform into our schema
@@ -130,18 +130,18 @@ def get_checkpoint(db, id_or_alias):
     """Returns checkpoint entry in `db` indicated by `id_or_alias`.
 
     First tries to match an ID, then an alias. For the case of repeated
-    aliases, will match first match local checkpoints and then remotes. In both
+    aliases, will first match local checkpoints and then remotes. In both
     cases, matching will be newest first.
     """
     # Go through the checkpoints ordered by creation date. There sholdn't be
     # repeated aliases, but if there are, prioritize the newest one.
     locals = sorted(
         [c for c in db['checkpoints'] if c['source'] == 'local'],
-        key=lambda c: c['created_date'], reverse=True
+        key=lambda c: c['created_at'], reverse=True
     )
     remotes = sorted(
         [c for c in db['checkpoints'] if c['source'] == 'remote'],
-        key=lambda c: c['created_date'], reverse=True
+        key=lambda c: c['created_at'], reverse=True
     )
 
     selected = []
@@ -396,7 +396,7 @@ def info(id_or_alias):
 
     click.echo()
 
-    click.echo('Creation date: {}'.format(checkpoint['created_date']))
+    click.echo('Creation date: {}'.format(checkpoint['created_at']))
     click.echo('Luminoth version: {}'.format(checkpoint['luminoth_version']))
 
     click.echo()
@@ -485,13 +485,11 @@ def create(config_files, override_params, entries):
             """.format(checkpoint_prefix)
         )
 
-    # Add the `classes.json` file.
-    if classes_path:
-        shutil.copy2(classes_path, path)
-
-    # Get the number of classes, if available.
+    # Add the `classes.json` file. Also get the number of classes, if
+    # available.
     num_classes = None
     if classes_path:
+        shutil.copy2(classes_path, path)
         with open(classes_path) as f:
             num_classes = len(json.load(f))
 
@@ -511,7 +509,7 @@ def create(config_files, override_params, entries):
         },
 
         'luminoth_version': lumi_version,
-        'created_date': datetime.utcnow().isoformat(),
+        'created_at': datetime.utcnow().isoformat(),
 
         'status': 'LOCAL',
         'source': 'local',

--- a/luminoth/tools/checkpoint/__init__.py
+++ b/luminoth/tools/checkpoint/__init__.py
@@ -604,7 +604,7 @@ def export(id_or_alias, output):
 
     # Create the tar that will contain the checkpoint.
     tar_path = os.path.join(
-        os.path.abspath(output),
+        os.path.abspath(os.path.expanduser(output)),
         '{}.tar'.format(checkpoint['id'])
     )
     checkpoint_path = get_checkpoint_path(checkpoint['id'])
@@ -633,6 +633,7 @@ def export(id_or_alias, output):
 @click.argument('path')
 def import_(path):
     # Load the checkpoint metadata first.
+    path = os.path.expanduser(path)
     try:
         with tarfile.open(path) as f:
             metadata = json.load(f.extractfile('metadata.json'))

--- a/luminoth/tools/server/static/style.css
+++ b/luminoth/tools/server/static/style.css
@@ -176,7 +176,7 @@ html {
   max-height: 500px;
   box-sizing: border-box;
 
-  width: 300px;
+  width: 310px;
   padding: 10px;
 
   border-radius: 5px;

--- a/luminoth/tools/server/templates/index.html
+++ b/luminoth/tools/server/templates/index.html
@@ -25,8 +25,8 @@
                 Probability threshold
               </label>
               <input id="prob-threshold" class="form-option-value"
-                     type="range" min="1" max="100" value="90" />
-              <span id="prob-threshold-value">0.90</span>
+                     type="range" min="1" max="100" value="70" />
+              <span id="prob-threshold-value">0.70</span>
             </div>
           </div>
           <div class="form-actions">

--- a/luminoth/tools/server/web.py
+++ b/luminoth/tools/server/web.py
@@ -73,8 +73,11 @@ def web(config_files, checkpoint, override_params, host, port, debug):
 
     if checkpoint:
         config = get_checkpoint_config(checkpoint)
-    else:
+    elif config_files:
         config = get_config(config_files)
+    else:
+        click.echo('You must specify either a checkpoint or a config file.')
+        return
 
     if override_params:
         config = override_config_params(config, override_params)

--- a/luminoth/utils/checkpoint_downloader.py
+++ b/luminoth/utils/checkpoint_downloader.py
@@ -5,6 +5,8 @@ import requests
 import tarfile
 import tensorflow as tf
 
+from luminoth.utils.homedir import get_luminoth_home
+
 
 TENSORFLOW_OFFICIAL_ENDPOINT = 'http://download.tensorflow.org/models/'
 
@@ -30,7 +32,7 @@ def get_default_path():
             job_dir = os.path.join(job_dir, 'pretrained_checkpoints/')
             return job_dir
 
-    return '~/.luminoth/'
+    return get_luminoth_home()
 
 
 DEFAULT_PATH = get_default_path()

--- a/luminoth/utils/config.py
+++ b/luminoth/utils/config.py
@@ -223,3 +223,10 @@ def get_model_config(base_config, custom_config, override_params):
 
     # Delete meta-keys before returning.
     return cleanup_config(config)
+
+
+def override_config_params(config, params):
+    """Overrides `config` with `params` and returns it."""
+    override_config = EasyDict(parse_override(params))
+    config = merge_into(override_config, config, overwrite=True)
+    return config

--- a/luminoth/utils/experiments.py
+++ b/luminoth/utils/experiments.py
@@ -4,8 +4,9 @@ import os.path
 import subprocess
 import tensorflow as tf
 
+from luminoth.utils.homedir import get_luminoth_home
 
-DEFAULT_BASE_PATH = os.path.expanduser('~/.luminoth')
+
 DEFAULT_FILENAME = 'runs.json'
 CURRENT_DIR = os.path.dirname(os.path.realpath(__file__))
 
@@ -45,7 +46,7 @@ def get_tensorflow_version():
 
 
 def save_run(config, environment=None, comment=None, extra_config=None,
-             base_path=DEFAULT_BASE_PATH, filename=DEFAULT_FILENAME):
+             filename=DEFAULT_FILENAME):
     if environment == 'cloud':
         # We don't write runs inside Google Cloud, we run it before.
         return
@@ -64,8 +65,9 @@ def save_run(config, environment=None, comment=None, extra_config=None,
         'extra_config': extra_config,
     }
 
-    file_path = os.path.join(base_path, filename)
-    tf.gfile.MakeDirs(base_path)
+    path = get_luminoth_home()
+    file_path = os.path.join(path, filename)
+    tf.gfile.MakeDirs(path)
 
     with tf.gfile.Open(file_path, 'a') as log:
         log.write(json.dumps(experiment) + '\n')

--- a/luminoth/utils/homedir.py
+++ b/luminoth/utils/homedir.py
@@ -1,0 +1,20 @@
+"""Luminoth home (~/.luminoth) management utilities."""
+import os
+
+
+DEFAULT_LUMINOTH_HOME = os.path.expanduser('~/.luminoth')
+
+
+def get_luminoth_home(create_if_missing=True):
+    """Returns Luminoth's homedir."""
+    # Get Luminoth's home directory (the default one or the overridden).
+    path = DEFAULT_LUMINOTH_HOME
+    if 'LUMI_HOME' in os.environ:
+        path = os.environ['LUMI_HOME']
+    path = os.path.abspath(path)
+
+    # Create the directory if it doesn't exist.
+    if create_if_missing and not os.path.exists(path):
+        os.makedirs(path, exist_ok=True)
+
+    return path

--- a/luminoth/utils/homedir.py
+++ b/luminoth/utils/homedir.py
@@ -1,5 +1,6 @@
 """Luminoth home (~/.luminoth) management utilities."""
 import os
+import tensorflow as tf
 
 
 DEFAULT_LUMINOTH_HOME = os.path.expanduser('~/.luminoth')
@@ -15,6 +16,6 @@ def get_luminoth_home(create_if_missing=True):
 
     # Create the directory if it doesn't exist.
     if create_if_missing and not os.path.exists(path):
-        os.makedirs(path, exist_ok=True)
+        tf.gfile.MakeDirs(path)
 
     return path

--- a/luminoth/utils/predicting.py
+++ b/luminoth/utils/predicting.py
@@ -6,7 +6,6 @@ import time
 
 from luminoth.models import get_model
 from luminoth.datasets import get_dataset
-from luminoth.utils.config import get_config
 
 
 class PredictorNetwork(object):
@@ -17,17 +16,7 @@ class PredictorNetwork(object):
     Returns a dictionary with the objects, their labels and probabilities,
     the inference time and the scale factor."""
 
-    def __init__(self, config_files, checkpoint):
-
-        if checkpoint:
-            # TODO: Move around. `PredictorNetwork` should receive config
-            # directly, not perform filesystem nor prompts to the user nor
-            # fail when not found.
-            # TODO: What if it's not found? (See above.)
-            from luminoth.tools.checkpoint import get_checkpoint_config
-            config = get_checkpoint_config(checkpoint)
-        else:
-            config = get_config(config_files)
+    def __init__(self, config):
 
         if config.dataset.dir:
             # Gets the names of the classes

--- a/luminoth/utils/predicting.py
+++ b/luminoth/utils/predicting.py
@@ -17,9 +17,25 @@ class PredictorNetwork(object):
     Returns a dictionary with the objects, their labels and probabilities,
     the inference time and the scale factor."""
 
-    def __init__(self, config_files):
+    def __init__(self, config_files, checkpoint):
 
-        config = get_config(config_files)
+        if checkpoint:
+            # TODO: Move around.
+            from luminoth.tools.checkpoint import (
+                get_checkpoint, get_checkpoint_path, read_checkpoint_db,
+                LUMINOTH_PATH, CHECKPOINT_PATH
+            )
+            # TODO: Move to `checkpoint` module.
+            db = read_checkpoint_db()
+            checkpoint = get_checkpoint(db, checkpoint)
+            path = get_checkpoint_path(checkpoint['id'])
+            config = get_config(os.path.join(path, 'config.yml'))
+            # TODO: Do the replacement some other way.
+            config.dataset.dir = path
+            config.train.job_dir = os.path.join(LUMINOTH_PATH, CHECKPOINT_PATH)
+        else:
+            config = get_config(config_files)
+
         if config.dataset.dir:
             # Gets the names of the classes
             classes_file = os.path.join(config.dataset.dir, 'classes.json')

--- a/luminoth/utils/predicting.py
+++ b/luminoth/utils/predicting.py
@@ -20,19 +20,12 @@ class PredictorNetwork(object):
     def __init__(self, config_files, checkpoint):
 
         if checkpoint:
-            # TODO: Move around.
-            from luminoth.tools.checkpoint import (
-                get_checkpoint, get_checkpoint_path, read_checkpoint_db,
-                LUMINOTH_PATH, CHECKPOINT_PATH
-            )
-            # TODO: Move to `checkpoint` module.
-            db = read_checkpoint_db()
-            checkpoint = get_checkpoint(db, checkpoint)
-            path = get_checkpoint_path(checkpoint['id'])
-            config = get_config(os.path.join(path, 'config.yml'))
-            # TODO: Do the replacement some other way.
-            config.dataset.dir = path
-            config.train.job_dir = os.path.join(LUMINOTH_PATH, CHECKPOINT_PATH)
+            # TODO: Move around. `PredictorNetwork` should receive config
+            # directly, not perform filesystem nor prompts to the user nor
+            # fail when not found.
+            # TODO: What if it's not found? (See above.)
+            from luminoth.tools.checkpoint import get_checkpoint_config
+            config = get_checkpoint_config(checkpoint)
         else:
             config = get_config(config_files)
 


### PR DESCRIPTION
Provides support for checkpoint management and usage. This allows using remote pre-trained checkpoints for different models directly in `lumi server web` and `lumi predict` commands.

Checkpoints may be created from existing runs and configuration files, or they may be downloaded from a remote repository. Once a checkpoint is available locally, it can be referenced in the above commands using the option `--checkpoint=<id_or_alias>`.

We're currently providing a single checkpoint with the Faster R-CNN model trained on the COCO dataset.

Fine-tuning existing checkpoints is not yet supported, but is on the roadmap.