### PR TITLE
Improve model evaluation and object proposals generation

### DIFF
--- a/luminoth/eval.py
+++ b/luminoth/eval.py
@@ -53,7 +53,10 @@ def eval(dataset_split, config_files, watch, from_global_step, override_params,
     config.dataset.data_augmentation = []
 
     # Override max detections with specified value.
-    config.model.rcnn.proposals.total_max_detections = max_detections
+    if config.model.network.with_rcnn:
+        config.model.rcnn.proposals.total_max_detections = max_detections
+    else:
+        config.model.rpn.proposals.post_nms_top_n = max_detections
 
     # Also overwrite `min_prob_threshold` in order to use all the detections.
     config.model.rcnn.proposals.min_prob_threshold = 0.0

--- a/luminoth/models/fasterrcnn/rcnn_test.py
+++ b/luminoth/models/fasterrcnn/rcnn_test.py
@@ -267,7 +267,10 @@ class RCNNTest(tf.test.TestCase):
         )
 
     def testNumberOfObjects(self):
-        """Tests we're not returning more objects than we get proposals.
+        """Tests we're not returning too many objects.
+
+        The number of objects returned should be lower than the number of
+        proposals received times the number of classes.
         """
 
         rcnn_net = self._shared_model(
@@ -292,7 +295,7 @@ class RCNNTest(tf.test.TestCase):
         # Assertions
         self.assertLessEqual(
             prediction_dict['objects'].shape[0],
-            self._num_proposals
+            self._num_proposals * self._num_classes
         )
 
     def testLoss(self):

--- a/luminoth/utils/training.py
+++ b/luminoth/utils/training.py
@@ -81,7 +81,7 @@ def get_optimizer(train_config, global_step=None):
     return optimizer_cls(learning_rate, **optimizer_config)
 
 
-def clip_gradients_by_norm(grads_and_vars, add_to_summary=True):
+def clip_gradients_by_norm(grads_and_vars, add_to_summary=False):
     if add_to_summary:
         for grad, var in grads_and_vars:
             if grad is not None:


### PR DESCRIPTION
- Fixes Faster R-CNN object proposals generation by not artificially limiting predictions.
- Fix mAP calculation code; now limiting by `max_detections` instead of `min_probability`.
- Implements COCO metric instead of Pascal VOC's, calculating mAP at different IoU thresholds (`[0.50:0.05:0.95]`).