### PR TITLE
Slim down checkpoints

### DIFF
--- a/luminoth/models/base/base_network.py
+++ b/luminoth/models/base/base_network.py
@@ -4,7 +4,8 @@ import sonnet as snt
 import tensorflow as tf
 import tensorflow.contrib.slim as slim
 
-from tensorflow.contrib.slim.nets import vgg, resnet_v2, resnet_v1
+from tensorflow.contrib.slim.nets import resnet_v2, resnet_v1
+from . import truncated_vgg_16 as vgg
 
 from luminoth.utils.checkpoint_downloader import get_checkpoint_file
 

--- a/luminoth/models/base/base_network.py
+++ b/luminoth/models/base/base_network.py
@@ -5,8 +5,8 @@ import tensorflow as tf
 import tensorflow.contrib.slim as slim
 
 from tensorflow.contrib.slim.nets import resnet_v2, resnet_v1, vgg
-from . import truncated_vgg
 
+from luminoth.models.base import truncated_vgg
 from luminoth.utils.checkpoint_downloader import get_checkpoint_file
 
 

--- a/luminoth/models/base/base_network.py
+++ b/luminoth/models/base/base_network.py
@@ -225,3 +225,13 @@ class BaseNetwork(snt.AbstractModule):
             )
 
         return all_variables[index:]
+
+    def get_base_checkpoint_vars(self):
+        variable_scope_len = len(self.variable_scope.name) + 1
+        var_list = self.get_base_network_vars()
+        var_map = {}
+        for var in var_list:
+            var_name = var.op.name
+            checkpoint_var_name = var_name[variable_scope_len:]
+            var_map[checkpoint_var_name] = var
+        return var_map

--- a/luminoth/models/base/truncated_base_network.py
+++ b/luminoth/models/base/truncated_base_network.py
@@ -13,7 +13,6 @@ DEFAULT_ENDPOINTS = {
     'resnet_v2_101': 'block3',
     'resnet_v2_152': 'block3',
     'vgg_16': 'conv5/conv5_3',
-    'vgg_19': 'conv5/conv5_4',
 }
 
 

--- a/luminoth/models/base/truncated_vgg.py
+++ b/luminoth/models/base/truncated_vgg.py
@@ -76,30 +76,18 @@ def vgg_arg_scope(weight_decay=0.0005):
             return arg_sc
 
 
-def truncated_vgg_16(inputs,
-                     num_classes=1000,
-                     is_training=True,
-                     dropout_keep_prob=0.5,
-                     spatial_squeeze=True,
-                     scope='vgg_16'):
+def truncated_vgg_16(inputs, is_training=True, scope='vgg_16'):
     """Oxford Net VGG 16-Layers version D Example.
 
-    Note: All the fully_connected layers have been transformed to conv2d
-          layers. To use in classification mode, resize input to 224x224.
+    For use in SSD object detection network, which has this particular
+    truncated version of VGG16 detailed in its paper.
 
     Args:
       inputs: a tensor of size [batch_size, height, width, channels].
-      num_classes: number of predicted classes.
-      is_training: whether or not the model is being trained.
-      dropout_keep_prob: the probability that activations are kept in the
-        dropout layers during training.
-      spatial_squeeze: whether or not should squeeze the spatial dimensions of
-        the outputs. Useful to remove unnecessary dimensions for
-        classification.
       scope: Optional scope for the variables.
 
     Returns:
-      the last op containing the log predictions and end_points dict.
+      the last op containing the conv5 tensor and end_points dict.
     """
     with variable_scope.variable_scope(scope, 'vgg_16', [inputs]) as sc:
         end_points_collection = sc.original_name_scope + '_end_points'

--- a/luminoth/models/base/truncated_vgg.py
+++ b/luminoth/models/base/truncated_vgg.py
@@ -41,7 +41,6 @@ Usage:
 
 @@vgg_a
 @@vgg_16
-@@vgg_19
 """
 
 from __future__ import absolute_import
@@ -77,16 +76,16 @@ def vgg_arg_scope(weight_decay=0.0005):
             return arg_sc
 
 
-def vgg_16(inputs,
-           num_classes=1000,
-           is_training=True,
-           dropout_keep_prob=0.5,
-           spatial_squeeze=True,
-           scope='vgg_16'):
+def truncated_vgg_16(inputs,
+                     num_classes=1000,
+                     is_training=True,
+                     dropout_keep_prob=0.5,
+                     spatial_squeeze=True,
+                     scope='vgg_16'):
     """Oxford Net VGG 16-Layers version D Example.
 
-    Note: All the fully_connected layers have been transformed to conv2d layers.
-          To use in classification mode, resize input to 224x224.
+    Note: All the fully_connected layers have been transformed to conv2d
+          layers. To use in classification mode, resize input to 224x224.
 
     Args:
       inputs: a tensor of size [batch_size, height, width, channels].
@@ -128,8 +127,10 @@ def vgg_16(inputs,
                 net, 3, layers.conv2d, 512, [3, 3], scope='conv5'
             )
             # Convert end_points_collection into a end_point dict.
-            end_points = utils.convert_collection_to_dict(end_points_collection)
+            end_points = utils.convert_collection_to_dict(
+                end_points_collection
+            )
             return net, end_points
 
 
-vgg_16.default_image_size = 224
+truncated_vgg_16.default_image_size = 224

--- a/luminoth/models/base/truncated_vgg_16.py
+++ b/luminoth/models/base/truncated_vgg_16.py
@@ -1,0 +1,135 @@
+# Copyright 2016 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+# ==============================================================================
+# Taken from tensorboard repository:
+# https://github.com/tensorflow/tensorflow/blob/master/tensorflow/contrib/slim/python/slim/nets/vgg.py
+# Modified to remove the fully connected layers from vgg16.
+# ==============================================================================
+"""Contains model definitions for versions of the Oxford VGG network.
+
+These model definitions were introduced in the following technical report:
+
+  Very Deep Convolutional Networks For Large-Scale Image Recognition
+  Karen Simonyan and Andrew Zisserman
+  arXiv technical report, 2015
+  PDF: http://arxiv.org/pdf/1409.1556.pdf
+  ILSVRC 2014 Slides: http://www.robots.ox.ac.uk/~karen/pdf/ILSVRC_2014.pdf
+  CC-BY-4.0
+
+More information can be obtained from the VGG website:
+www.robots.ox.ac.uk/~vgg/research/very_deep/
+
+Usage:
+  with slim.arg_scope(vgg.vgg_arg_scope()):
+    outputs, end_points = vgg.vgg_a(inputs)
+
+  with slim.arg_scope(vgg.vgg_arg_scope()):
+    outputs, end_points = vgg.vgg_16(inputs)
+
+@@vgg_a
+@@vgg_16
+@@vgg_19
+"""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+from tensorflow.contrib import layers
+from tensorflow.contrib.framework.python.ops import arg_scope
+from tensorflow.contrib.layers.python.layers import layers as layers_lib
+from tensorflow.contrib.layers.python.layers import regularizers
+from tensorflow.contrib.layers.python.layers import utils
+from tensorflow.python.ops import init_ops
+from tensorflow.python.ops import nn_ops
+from tensorflow.python.ops import variable_scope
+
+
+def vgg_arg_scope(weight_decay=0.0005):
+    """Defines the VGG arg scope.
+
+    Args:
+      weight_decay: The l2 regularization coefficient.
+
+    Returns:
+      An arg_scope.
+    """
+    with arg_scope(
+        [layers.conv2d, layers_lib.fully_connected],
+        activation_fn=nn_ops.relu,
+        weights_regularizer=regularizers.l2_regularizer(weight_decay),
+        biases_initializer=init_ops.zeros_initializer()
+    ):
+        with arg_scope([layers.conv2d], padding='SAME') as arg_sc:
+            return arg_sc
+
+
+def vgg_16(inputs,
+           num_classes=1000,
+           is_training=True,
+           dropout_keep_prob=0.5,
+           spatial_squeeze=True,
+           scope='vgg_16'):
+    """Oxford Net VGG 16-Layers version D Example.
+
+    Note: All the fully_connected layers have been transformed to conv2d layers.
+          To use in classification mode, resize input to 224x224.
+
+    Args:
+      inputs: a tensor of size [batch_size, height, width, channels].
+      num_classes: number of predicted classes.
+      is_training: whether or not the model is being trained.
+      dropout_keep_prob: the probability that activations are kept in the
+        dropout layers during training.
+      spatial_squeeze: whether or not should squeeze the spatial dimensions of
+        the outputs. Useful to remove unnecessary dimensions for
+        classification.
+      scope: Optional scope for the variables.
+
+    Returns:
+      the last op containing the log predictions and end_points dict.
+    """
+    with variable_scope.variable_scope(scope, 'vgg_16', [inputs]) as sc:
+        end_points_collection = sc.original_name_scope + '_end_points'
+        # Collect outputs for conv2d, fully_connected and max_pool2d.
+        with arg_scope(
+            [layers.conv2d, layers_lib.fully_connected, layers_lib.max_pool2d],
+            outputs_collections=end_points_collection
+        ):
+            net = layers_lib.repeat(
+                inputs, 2, layers.conv2d, 64, [3, 3], scope='conv1')
+            net = layers_lib.max_pool2d(net, [2, 2], scope='pool1')
+            net = layers_lib.repeat(
+                net, 2, layers.conv2d, 128, [3, 3], scope='conv2'
+            )
+            net = layers_lib.max_pool2d(net, [2, 2], scope='pool2')
+            net = layers_lib.repeat(
+                net, 3, layers.conv2d, 256, [3, 3], scope='conv3'
+            )
+            net = layers_lib.max_pool2d(net, [2, 2], scope='pool3')
+            net = layers_lib.repeat(
+                net, 3, layers.conv2d, 512, [3, 3], scope='conv4'
+            )
+            net = layers_lib.max_pool2d(net, [2, 2], scope='pool4')
+            net = layers_lib.repeat(
+                net, 3, layers.conv2d, 512, [3, 3], scope='conv5'
+            )
+            # Convert end_points_collection into a end_point dict.
+            end_points = utils.convert_collection_to_dict(end_points_collection)
+            return net, end_points
+
+
+vgg_16.default_image_size = 224

--- a/luminoth/models/fasterrcnn/fasterrcnn.py
+++ b/luminoth/models/fasterrcnn/fasterrcnn.py
@@ -357,12 +357,8 @@ class FasterRCNN(snt.AbstractModule):
 
         return trainable_vars
 
-    def get_saver(self, ignore_scope=None):
-        """Get an instance of tf.train.Saver for all modules and submodules.
-        """
-        return get_saver((self, self.base_network), ignore_scope=ignore_scope)
+    def get_base_checkpoint_vars(self):
+        return self.base_network.get_base_checkpoint_vars()
 
-    def load_pretrained_weights(self):
-        """Get operation to load pretrained weights from file.
-        """
-        return self.base_network.load_weights()
+    def get_checkpoint_file(self):
+        return self.base_network.get_checkpoint_file()

--- a/luminoth/models/fasterrcnn/fasterrcnn.py
+++ b/luminoth/models/fasterrcnn/fasterrcnn.py
@@ -6,7 +6,7 @@ from luminoth.models.fasterrcnn.rcnn import RCNN
 from luminoth.models.fasterrcnn.rpn import RPN
 from luminoth.models.base import TruncatedBaseNetwork
 from luminoth.utils.anchors import generate_anchors_reference
-from luminoth.utils.vars import VAR_LOG_LEVELS, variable_summaries, get_saver
+from luminoth.utils.vars import VAR_LOG_LEVELS, variable_summaries
 
 
 class FasterRCNN(snt.AbstractModule):

--- a/luminoth/models/fasterrcnn/fasterrcnn.py
+++ b/luminoth/models/fasterrcnn/fasterrcnn.py
@@ -357,8 +357,8 @@ class FasterRCNN(snt.AbstractModule):
 
         return trainable_vars
 
-    def get_base_checkpoint_vars(self):
-        return self.base_network.get_base_checkpoint_vars()
+    def get_base_network_checkpoint_vars(self):
+        return self.base_network.get_base_network_checkpoint_vars()
 
     def get_checkpoint_file(self):
         return self.base_network.get_checkpoint_file()

--- a/luminoth/models/ssd/base_config.yml
+++ b/luminoth/models/ssd/base_config.yml
@@ -96,8 +96,8 @@ dataset:
           lower: 0.5
           upper: 1.5
         prob: 0.5
-#   - expand:
-#       prob: 0.5
+   - expand:
+       prob: 0.5
 
 model:
   type: ssd

--- a/luminoth/models/ssd/base_config.yml
+++ b/luminoth/models/ssd/base_config.yml
@@ -96,8 +96,8 @@ dataset:
           lower: 0.5
           upper: 1.5
         prob: 0.5
-   - expand:
-       prob: 0.5
+    - expand:
+        prob: 0.5
 
 model:
   type: ssd

--- a/luminoth/models/ssd/base_config.yml
+++ b/luminoth/models/ssd/base_config.yml
@@ -107,7 +107,7 @@ model:
 
   base_network:
     # Which type of pretrained network to use
-    architecture: vgg_16
+    architecture: truncated_vgg_16
     # Should we train the pretrained network
     trainable: True
     # From which file to load the weights

--- a/luminoth/models/ssd/feature_extractor.py
+++ b/luminoth/models/ssd/feature_extractor.py
@@ -1,3 +1,4 @@
+import sonnet as snt
 import tensorflow as tf
 
 from sonnet.python.modules.conv import Conv2D
@@ -131,3 +132,23 @@ class SSDFeatureExtractor(BaseNetwork):
 
         # It's actually an ordered dict
         return utils.convert_collection_to_dict('FEATURE_MAPS')
+
+    def get_trainable_vars(self):
+        """
+        Returns a list of the variables that are trainable.
+
+        Returns:
+            trainable_variables: a tuple of `tf.Variable`.
+        """
+        # TODO hacer que esto filtre las fully connected de VGG!
+        return snt.get_variables_in_module(self)
+
+    def get_base_checkpoint_vars(self):
+        variable_scope_len = len(self.variable_scope.name) + 1
+        var_list = super(SSDFeatureExtractor, self).get_base_network_vars()
+        var_map = {}
+        for var in var_list:
+            var_name = var.op.name
+            checkpoint_var_name = var_name[variable_scope_len:]
+            var_map[checkpoint_var_name] = var
+        return var_map

--- a/luminoth/models/ssd/feature_extractor.py
+++ b/luminoth/models/ssd/feature_extractor.py
@@ -3,8 +3,6 @@ import tensorflow as tf
 
 from sonnet.python.modules.conv import Conv2D
 from tensorflow.contrib.layers.python.layers import utils
-from tensorflow.contrib.framework.python.ops import variables
-from tensorflow.python.ops import init_ops
 
 from luminoth.models.base import BaseNetwork
 

--- a/luminoth/models/ssd/feature_extractor.py
+++ b/luminoth/models/ssd/feature_extractor.py
@@ -140,13 +140,3 @@ class SSDFeatureExtractor(BaseNetwork):
         """
         # TODO hacer que esto filtre las fully connected de VGG!
         return snt.get_variables_in_module(self)
-
-    def get_base_checkpoint_vars(self):
-        variable_scope_len = len(self.variable_scope.name) + 1
-        var_list = super(SSDFeatureExtractor, self).get_base_network_vars()
-        var_map = {}
-        for var in var_list:
-            var_name = var.op.name
-            checkpoint_var_name = var_name[variable_scope_len:]
-            var_map[checkpoint_var_name] = var
-        return var_map

--- a/luminoth/models/ssd/feature_extractor.py
+++ b/luminoth/models/ssd/feature_extractor.py
@@ -8,7 +8,7 @@ from luminoth.models.base import BaseNetwork
 
 
 VALID_SSD_ARCHITECTURES = set([
-    'vgg_16',
+    'truncated_vgg_16',
 ])
 
 
@@ -52,7 +52,7 @@ class SSDFeatureExtractor(BaseNetwork):
         base_net_endpoints = super(SSDFeatureExtractor, self)._build(
             inputs, is_training=is_training)['end_points']
 
-        if self.vgg_16_type:
+        if self.truncated_vgg_16_type:
             # As it is pointed out in SSD and ParseNet papers, `conv4_3` has a
             # different features scale compared to other layers, to adjust it
             # we need to add a spatial normalization before adding the

--- a/luminoth/models/ssd/feature_extractor.py
+++ b/luminoth/models/ssd/feature_extractor.py
@@ -138,5 +138,4 @@ class SSDFeatureExtractor(BaseNetwork):
         Returns:
             trainable_variables: a tuple of `tf.Variable`.
         """
-        # TODO hacer que esto filtre las fully connected de VGG!
         return snt.get_variables_in_module(self)

--- a/luminoth/models/ssd/ssd.py
+++ b/luminoth/models/ssd/ssd.py
@@ -330,11 +330,5 @@ class SSD(snt.AbstractModule):
     def get_base_checkpoint_vars(self):
         return self.feature_extractor.get_base_checkpoint_vars()
 
-    def get_saver(self, ignore_scope=None):
-        """Get an instance of tf.train.Saver for all modules and submodules.
-        """
-        return get_saver((self, self.feature_extractor),
-                         ignore_scope=ignore_scope)
-
     def get_checkpoint_file(self):
         return self.feature_extractor.get_checkpoint_file()

--- a/luminoth/models/ssd/ssd.py
+++ b/luminoth/models/ssd/ssd.py
@@ -327,8 +327,8 @@ class SSD(snt.AbstractModule):
 
         return trainable_vars
 
-    def get_base_checkpoint_vars(self):
-        return self.feature_extractor.get_base_checkpoint_vars()
+    def get_base_network_checkpoint_vars(self):
+        return self.feature_extractor.get_base_network_checkpoint_vars()
 
     def get_checkpoint_file(self):
         return self.feature_extractor.get_checkpoint_file()

--- a/luminoth/models/ssd/ssd.py
+++ b/luminoth/models/ssd/ssd.py
@@ -69,7 +69,6 @@ class SSD(snt.AbstractModule):
             self._config.base_network, parent_name=self.module_name
         )
         feature_maps = self.feature_extractor(image, is_training=is_training)
-        # import ipdb; ipdb.set_trace()
 
         # Build a MultiBox predictor on top of each feature layer and collect
         # the bounding box offsets and the category score logits they produce

--- a/luminoth/models/ssd/ssd.py
+++ b/luminoth/models/ssd/ssd.py
@@ -11,7 +11,6 @@ from luminoth.models.ssd.utils import (
     generate_raw_anchors, adjust_bboxes
 )
 from luminoth.utils.losses import smooth_l1_loss
-from luminoth.utils.vars import get_saver
 from luminoth.utils.bbox_transform import clip_boxes
 
 
@@ -86,7 +85,9 @@ class SSD(snt.AbstractModule):
                     num_anchors * 4, [3, 3],
                     name=multibox_predictor_name + '_offsets_conv'
                 )(feat_map)
-                bbox_offsets_flattened = tf.reshape(bbox_offsets_layer, [-1, 4])
+                bbox_offsets_flattened = tf.reshape(
+                    bbox_offsets_layer, [-1, 4]
+                )
                 bbox_offsets_list.append(bbox_offsets_flattened)
 
                 # Predict class scores

--- a/luminoth/models/ssd/utils.py
+++ b/luminoth/models/ssd/utils.py
@@ -15,7 +15,6 @@ def adjust_bboxes(bboxes, old_height, old_width, new_height, new_width):
         Tensor with shape (num_bboxes, 4), with the adjusted bboxes.
     """
     # x_min, y_min, x_max, y_max = np.split(bboxes, 4, axis=1)
-    # import ipdb; ipdb.set_trace()
     x_min = bboxes[:, 0] / old_width
     y_min = bboxes[:, 1] / old_height
     x_max = bboxes[:, 2] / old_width

--- a/luminoth/train.py
+++ b/luminoth/train.py
@@ -92,7 +92,8 @@ def run(config, target='', cluster_spec=None, is_chief=True, job_name=None,
 
         # Create custom init for slots in optimizer, as we don't save them to
         # our checkpoints. An example of slots in an optimizer are the Momentum
-        # variables in MomentumOptimizer.
+        # variables in MomentumOptimizer. We do this because slot variables can
+        # effectively duplicate the size of your checkpoint!
         slot_variables = [
             optimizer.get_slot(var, name)
             for name in optimizer.get_slot_names()
@@ -111,7 +112,7 @@ def run(config, target='', cluster_spec=None, is_chief=True, job_name=None,
         )
 
         # Create saver for loading pretrained checkpoint into base network
-        base_checkpoint_vars = model.get_base_checkpoint_vars()
+        base_checkpoint_vars = model.get_base_network_checkpoint_vars()
         checkpoint_file = model.get_checkpoint_file()
         if base_checkpoint_vars and checkpoint_file:
             base_net_checkpoint_saver = tf.train.Saver(

--- a/luminoth/train.py
+++ b/luminoth/train.py
@@ -90,11 +90,12 @@ def run(config, target='', cluster_spec=None, is_chief=True, job_name=None,
                 grads_and_vars, global_step=global_step
             )
 
-        # Create custom init for slots in optimizer, as we don't save them to our
-        # checkpoints. An example of slots in an optimizer are the Momentum
+        # Create custom init for slots in optimizer, as we don't save them to
+        # our checkpoints. An example of slots in an optimizer are the Momentum
         # variables in MomentumOptimizer.
         slot_variables = [
-            optimizer.get_slot(var, name) for name in optimizer.get_slot_names()
+            optimizer.get_slot(var, name)
+            for name in optimizer.get_slot_names()
             for var in trainable_vars
         ]
         slot_init = tf.variables_initializer(

--- a/luminoth/train.py
+++ b/luminoth/train.py
@@ -110,16 +110,21 @@ def run(config, target='', cluster_spec=None, is_chief=True, job_name=None,
         )
 
         # Create saver for loading pretrained checkpoint into base network
-        base_net_checkpoint_saver = tf.train.Saver(
-            model.get_base_checkpoint_vars(),
-            name='base_net_checkpoint_saver'
-        )
-
-        # We'll send this fn to Scaffold init_fn
-        def load_base_net_checkpoint(_, session):
-            base_net_checkpoint_saver.restore(
-                session, model.get_checkpoint_file()
+        base_checkpoint_vars = model.get_base_checkpoint_vars()
+        checkpoint_file = model.get_checkpoint_file()
+        if base_checkpoint_vars and checkpoint_file:
+            base_net_checkpoint_saver = tf.train.Saver(
+                base_checkpoint_vars,
+                name='base_net_checkpoint_saver'
             )
+
+            # We'll send this fn to Scaffold init_fn
+            def load_base_net_checkpoint(_, session):
+                base_net_checkpoint_saver.restore(
+                    session, checkpoint_file
+                )
+        else:
+            load_base_net_checkpoint = None
 
     tf.logging.info('{}Starting training for {}'.format(log_prefix, model))
 

--- a/luminoth/train_test.py
+++ b/luminoth/train_test.py
@@ -31,6 +31,12 @@ class MockFasterRCNN(snt.AbstractModule):
     def load_pretrained_weights(self):
         return tf.no_op()
 
+    def get_base_checkpoint_vars(self):
+        return None
+
+    def get_checkpoint_file(self):
+        return None
+
     @property
     def summary(self):
         return tf.summary.scalar('dummy', 1, collections=['rcnn'])

--- a/luminoth/train_test.py
+++ b/luminoth/train_test.py
@@ -28,7 +28,7 @@ class MockFasterRCNN(snt.AbstractModule):
     def get_trainable_vars(self):
         return snt.get_variables_in_module(self)
 
-    def get_base_checkpoint_vars(self):
+    def get_base_network_checkpoint_vars(self):
         return None
 
     def get_checkpoint_file(self):

--- a/luminoth/utils/checkpoint_downloader.py
+++ b/luminoth/utils/checkpoint_downloader.py
@@ -19,7 +19,7 @@ BASE_NETWORK_FILENAMES = {
     'resnet_v2_101': 'resnet_v2_101_2017_04_14.tar.gz',
     'resnet_v2_152': 'resnet_v2_152_2017_04_14.tar.gz',
     'vgg_16': 'vgg_16_2016_08_28.tar.gz',
-    'vgg_19': 'vgg_19_2016_08_28.tar.gz',
+    'truncated_vgg_16': 'vgg_16_2016_08_28.tar.gz',
 }
 
 
@@ -74,8 +74,10 @@ def download_checkpoint(network, network_filename, checkpoint_path,
     tmp_tarball = tf.gfile.Open(tarball_path, 'rb')
     # Open tarfile object
     tar_obj = tarfile.open(fileobj=tmp_tarball)
+    # Get checkpoint file name
+    checkpoint_file_name = tar_obj.getnames()[0]
     # Create buffer with extracted network checkpoint
-    checkpoint_fp = tar_obj.extractfile(network_filename)
+    checkpoint_fp = tar_obj.extractfile(checkpoint_file_name)
     # Define where to save.
     checkpoint_file = tf.gfile.Open(checkpoint_filename, 'wb')
     # Write extracted checkpoint to file

--- a/luminoth/utils/vars.py
+++ b/luminoth/utils/vars.py
@@ -1,6 +1,4 @@
 import tensorflow as tf
-import sonnet as snt
-import collections
 
 
 VALID_INITIALIZERS = {
@@ -88,43 +86,3 @@ def get_activation_function(activation_function):
     except AttributeError:
         raise ValueError(
             'Invalid activation function "{}"'.format(activation_function))
-
-
-def get_saver(modules, var_collections=(tf.GraphKeys.GLOBAL_VARIABLES,),
-              ignore_scope=None, **kwargs):
-    """Get tf.train.Saver instance for module.
-
-    Args:
-        - modules: Sonnet module or list of Sonnet modules from where to
-            extract variables.
-        - var_collections: Collections from where to take variables.
-        - ignore_scope (str): Ignore variables that contain scope in name.
-        - kwargs: Keyword arguments to pass to creation of `tf.train.Saver`.
-
-    Returns:
-        - saver: tf.train.Saver instance.
-    """
-    if not isinstance(modules, collections.Iterable):
-        modules = [modules]
-
-    variable_map = {}
-    for module in modules:
-        for collection in var_collections:
-            model_variables = snt.get_normalized_variable_map(
-                module, collection
-            )
-            total_model_variables = len(model_variables)
-            if ignore_scope:
-                model_variables = {
-                    k: v for k, v in model_variables.items()
-                    if ignore_scope not in k
-                }
-                new_total_model_variables = len(model_variables)
-                tf.logging.info(
-                    'Not loading/saving {} variables with scope "{}"'.format(
-                        total_model_variables - new_total_model_variables,
-                        ignore_scope))
-
-            variable_map.update(model_variables)
-
-    return tf.train.Saver(var_list=variable_map, **kwargs)


### PR DESCRIPTION
Improve checkpoint creation, resulting in:
- Much simpler init operations (much faster training start up time).
- Much smaller checkpoints (eg.: FasterRCNN: `537MB -> 190MB`, SSD: `1,731MB -> 103MB`).

Also smaller changes: Improve SSD initialization (faster training), Improve testing on train.py