### PR TITLE
Better setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,27 +15,39 @@ Read the full documentation [here](http://luminoth.readthedocs.io/).
 > **DISCLAIMER**: Luminoth is still alpha-quality release, which means the internal and external interfaces (such as command line) are very likely to change as the codebase matures.
 
 # Installation
+
 Luminoth currently supports Python 2.7 and 3.4–3.6.
 
 ## Pre-requisites
-If you want **GPU support**, you should install the GPU version of [TensorFlow](https://www.tensorflow.org/install/).
-If TensorFlow is is already installed, Luminoth will use that version (no matter if CPU or GPU versions).
+
+To use Luminoth, [TensorFlow](https://www.tensorflow.org/install/) must be installed beforehand. If you want **GPU support**, you should install the GPU version of TensorFlow with `pip install tensorflow-gpu`, or else you can use the CPU version using `pip install tensorflow`.
 
 ## Installing Luminoth
+
 Just install from PyPI:
 
 ```bash
-$ pip install luminoth
+pip install luminoth
+```
+
+Optionally, Luminoth can also install TensorFlow for you if you install it with `pip install luminoth[tf]` or `pip install luminoth[tf-gpu]`, depending on the version of TensorFlow you wish to use.
+
+### Google Cloud
+
+If you wish to train using **Google Cloud ML Engine**, the optional dependencies must be installed:
+
+```bash
+pip install luminoth[gcloud]
 ```
 
 ## Installing from source
 
 First, clone the repo on your machine and then install with `pip`:
 
-```
-$ git clone https://github.com/tryolabs/luminoth.git
-$ cd luminoth
-$ pip install -e .
+```bash
+git clone https://github.com/tryolabs/luminoth.git
+cd luminoth
+pip install -e .
 ```
 
 ## Check that the installation worked
@@ -47,8 +59,8 @@ Simply run `lumi --help`.
 Currently, we support the following models:
 
 * **Object Detection**
-    * [Faster R-CNN](https://arxiv.org/abs/1506.01497)
-    * [SSD](https://arxiv.org/abs/1512.02325)
+  * [Faster R-CNN](https://arxiv.org/abs/1506.01497)
+  * [SSD](https://arxiv.org/abs/1512.02325)
 
 We are planning on adding support for more models in the near future, such as [RetinaNet](https://arxiv.org/abs/1708.02002) and [Mask R-CNN](https://arxiv.org/abs/1703.06870).
 
@@ -63,6 +75,7 @@ There is one main command line interface which you can use with the `lumi` comma
 and a list of available options with descriptions will show up.
 
 ## Working with datasets
+
 See [Adapting a dataset](http://luminoth.readthedocs.io/en/latest/usage/dataset.html).
 
 ## Training
@@ -75,16 +88,18 @@ We strive to get useful and understandable summary and graph visualizations. We 
 
 By default summary and graph logs are saved to `jobs/` under the current directory. You can use TensorBoard by running:
 
-```
+```bash
 tensorboard --logdir path/to/jobs
 ```
 
 ## Why the name?
+
 > The Dark Visor is a Visor upgrade in Metroid Prime 2: Echoes. Designed by the **Luminoth** during the war, it was used by the Champion of Aether, A-Kul, to penetrate Dark Aether's haze in battle against the Ing.
 >
 > -- [Dark Visor - Wikitroid](http://metroid.wikia.com/wiki/Dark_Visor)
 >
 
 # License
+
 Copyright © 2018, [Tryolabs](https://tryolabs.com).
 Released under the [BSD 3-Clause](LICENSE).

--- a/docs/usage/installation.rst
+++ b/docs/usage/installation.rst
@@ -6,21 +6,15 @@ Installation
 Before you start
 ----------------
 
-Tensorflow
+TensorFlow
 ^^^^^^^^^^
 
-All Luminoth dependencies will be downloaded automatically when you install
-Luminoth. However, `Tensorflow <https://tensorflow.org>`_, upon which Luminoth
-depends, provides two packages in PyPI: ``tensorflow`` (the CPU version) and
-``tensorflow-gpu`` (the GPU version).
+To use Luminoth, `TensorFlow <https://tensorflow.org>`_ must be installed beforehand.
+If you want **GPU support**, you should install the GPU version of TensorFlow with
+``pip install tensorflow-gpu``, or else you can use the CPU version using
+``pip install tensorflow``.
 
-Luminoth will default to the CPU version of the dependency. So, if you have a
-GPU, you should manually pre-install ``tensorflow-gpu`` before installing
-Luminoth by issuing::
-
-  $ pip install tensorflow-gpu
-
-You can see more details into installing Tensorflow manually `here
+You can see more details into installing TensorFlow manually `here
 <https://www.tensorflow.org/install/>`_, including how to use CUDA and cuDNN.
 
 FFmpeg
@@ -30,12 +24,22 @@ Luminoth leverages `FFmpeg <https://www.ffmpeg.org>`_ in order to support
 running predictions on videos. If you plan to use Luminoth with this end,
 FFmpeg should be installed as a system dependency.
 
+
 Installing from PyPI
 --------------------
 
 Use ``pip`` to install Luminoth, by running the following command::
 
   $ pip install luminoth
+
+Google Cloud
+^^^^^^^^^^^^
+
+If you wish to train using **Google Cloud ML Engine**, the optional dependencies
+must be installed::
+
+  $ pip install luminoth[gcloud]
+
 
 Installing from source
 ----------------------

--- a/luminoth/__init__.py
+++ b/luminoth/__init__.py
@@ -18,7 +18,7 @@ import sys
 
 # Check for a current TensorFlow installation.
 try:
-    import tensorflow
+    import tensorflow  # noqa: F401
 except ImportError:
     sys.exit("""Luminoth requires a TensorFlow >= {} installation.
 

--- a/luminoth/__init__.py
+++ b/luminoth/__init__.py
@@ -11,6 +11,21 @@ __email__ = 'luminoth@tryolabs.com'
 __license__ = 'BSD 3-Clause License'
 __copyright__ = 'Copyright (c) 2018 Tryolabs S.A.'
 
+__min_tf_version__ = '1.5'
+
+
+import sys
+
+# Check for a current TensorFlow installation.
+try:
+    import tensorflow
+except ImportError:
+    sys.exit("""Luminoth requires a TensorFlow >= {} installation.
+
+Depending on your use case, you should install either `tensorflow` or
+`tensorflow-gpu` packages manually or via PyPI.""".format(__min_tf_version__))
+
+
 # Import functions that are part of Luminoth's public interface.
 from luminoth.cli import cli  # noqa
 from luminoth.utils.predicting import PredictorNetwork  # noqa

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,7 @@
 import codecs
 import os
 import re
+import sys
 
 from setuptools import find_packages, setup
 
@@ -33,27 +34,33 @@ CLASSIFIERS = [
     'Programming Language :: Python :: 3.6',
 ]
 
-MIN_TENSORFLOW_VERSION = '1.3.0'
+MIN_TENSORFLOW_VERSION = '1.5'
 
 INSTALL_REQUIRES = [
     'numpy',
     'Pillow',
     'lxml',
+    'requests',
     'dm-sonnet>=1.12',
     'click>=6.7,<7',
     'PyYAML>=3.12,<4',
     'easydict>=1.7,<2',
-    'google-api-python-client>=1.6.2,<2',
-    'google-cloud-storage>=1.2.0',
     'Flask>=0.12',
     'six>=1.11',
-    'sk-video',
-    'pyasn1>=0.4.2',
-    'oauth2client>=4.1.2',
+    'sk-video'
 ]
 TEST_REQUIRES = []
 
 # -------------------------------------------------------------
+
+# Check for a current TensorFlow installation.
+try:
+    import tensorflow
+except ImportError:
+    sys.exit("""Luminoth requires a TensorFlow >= {} installation.
+
+Depending on your use case, you should install either `tensorflow` or
+`tensorflow-gpu` packages manually or via PyPI.""".format(MIN_TENSORFLOW_VERSION))
 
 
 HERE = os.path.abspath(os.path.dirname(__file__))
@@ -84,17 +91,6 @@ def find_meta(meta):
     raise RuntimeError('Unable to find __{meta}__ string.'.format(meta=meta))
 
 
-#
-# If TensorFlow is not installed, install it using the CPU version by default.
-# If the user wants to use the version with GPU support, it must be installed
-# in advance.
-#
-try:
-    import tensorflow
-except ImportError:
-    INSTALL_REQUIRES += ['tensorflow>={}'.format(MIN_TENSORFLOW_VERSION)]
-
-
 setup(
     name=NAME,
     version=find_meta('version'),
@@ -114,9 +110,13 @@ setup(
     install_requires=INSTALL_REQUIRES,
     test_requires=TEST_REQUIRES,
     extras_require={
-        'gpu support': [
-            'tensorflow-gpu>={}'.format(MIN_TENSORFLOW_VERSION),
-        ],
+        'gcloud': [
+            'google-api-python-client>=1.6.2,<2',
+            'google-cloud-storage>=1.2.0',
+            'oauth2client>=4.1.2',
+            # See https://github.com/tryolabs/luminoth/issues/147
+            'pyasn1>=0.4.2',
+        ]
     },
     entry_points="""
         [console_scripts]

--- a/setup.py
+++ b/setup.py
@@ -34,8 +34,6 @@ CLASSIFIERS = [
     'Programming Language :: Python :: 3.6',
 ]
 
-MIN_TENSORFLOW_VERSION = '1.5'
-
 INSTALL_REQUIRES = [
     'numpy',
     'Pillow',
@@ -52,16 +50,6 @@ INSTALL_REQUIRES = [
 TEST_REQUIRES = []
 
 # -------------------------------------------------------------
-
-# Check for a current TensorFlow installation.
-try:
-    import tensorflow
-except ImportError:
-    sys.exit("""Luminoth requires a TensorFlow >= {} installation.
-
-Depending on your use case, you should install either `tensorflow` or
-`tensorflow-gpu` packages manually or via PyPI.""".format(MIN_TENSORFLOW_VERSION))
-
 
 HERE = os.path.abspath(os.path.dirname(__file__))
 
@@ -89,6 +77,9 @@ def find_meta(meta):
     if meta_match:
         return meta_match.group(1)
     raise RuntimeError('Unable to find __{meta}__ string.'.format(meta=meta))
+
+
+MIN_TF_VERSION = find_meta('min_tf_version')
 
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -101,6 +101,8 @@ setup(
     install_requires=INSTALL_REQUIRES,
     test_requires=TEST_REQUIRES,
     extras_require={
+        'tf': ['tensorflow>={}'.format(MIN_TF_VERSION)],
+        'tf-gpu': ['tensorflow-gpu>='.format(MIN_TF_VERSION)],
         'gcloud': [
             'google-api-python-client>=1.6.2,<2',
             'google-cloud-storage>=1.2.0',

--- a/setup.py
+++ b/setup.py
@@ -35,17 +35,17 @@ CLASSIFIERS = [
 ]
 
 INSTALL_REQUIRES = [
-    'numpy',
     'Pillow',
     'lxml',
+    'numpy',
     'requests',
-    'dm-sonnet>=1.12',
-    'click>=6.7,<7',
-    'PyYAML>=3.12,<4',
-    'easydict>=1.7,<2',
+    'scikit-video',
     'Flask>=0.12',
+    'PyYAML>=3.12,<4',
+    'click>=6.7,<7',
+    'dm-sonnet>=1.12',
+    'easydict>=1.7,<2',
     'six>=1.11',
-    'sk-video'
 ]
 TEST_REQUIRES = []
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,6 @@
 [tox]
 envlist = py{27,34,35,36}
+skipsdist = true
 
 [testenv]
 passenv = TOXENV CI TRAVIS TRAVIS_*
@@ -7,9 +8,10 @@ deps=
     flake8
     codecov
     check-manifest
+    tensorflow
 commands =
-    pip install -e .
     check-manifest
     flake8 luminoth
+    pip install -e .
     coverage run -m unittest discover -s luminoth -p "*_test.py"
     codecov -e TOXENV


### PR DESCRIPTION
* Do not enforce or install any TF version during installation.
* Graceful message as soon as `lumi` is run and Tensorflow import fails.
* Google Cloud dependencies are optional now, and Luminoth won't ask unless you use that functionality.
* Updated readme and docs.