### PR TITLE
Overhaul of the Python API

### DIFF
--- a/luminoth/__init__.py
+++ b/luminoth/__init__.py
@@ -29,3 +29,4 @@ Depending on your use case, you should install either `tensorflow` or
 # Import functions that are part of Luminoth's public interface.
 from luminoth.cli import cli  # noqa
 from luminoth.tasks import Detector  # noqa
+from luminoth.vis import vis_objects  # noqa

--- a/luminoth/__init__.py
+++ b/luminoth/__init__.py
@@ -28,4 +28,4 @@ Depending on your use case, you should install either `tensorflow` or
 
 # Import functions that are part of Luminoth's public interface.
 from luminoth.cli import cli  # noqa
-from luminoth.utils.predicting import PredictorNetwork  # noqa
+from luminoth.tasks import Detector  # noqa

--- a/luminoth/__init__.py
+++ b/luminoth/__init__.py
@@ -28,5 +28,6 @@ Depending on your use case, you should install either `tensorflow` or
 
 # Import functions that are part of Luminoth's public interface.
 from luminoth.cli import cli  # noqa
+from luminoth.io import read_image  # noqa
 from luminoth.tasks import Detector  # noqa
 from luminoth.vis import vis_objects  # noqa

--- a/luminoth/io.py
+++ b/luminoth/io.py
@@ -1,0 +1,17 @@
+import numpy as np
+import os
+
+from PIL import Image
+
+
+def read_image(path):
+    """Reads an image located at `path` into an array.
+
+    Arguments:
+        path (str): Path to a valid image file in the filesystem.
+
+    Returns:
+        `numpy.ndarray` of size `(height, width, channels)`.
+    """
+    full_path = os.path.expanduser(path)
+    return np.array(Image.open(full_path).convert('RGB'))

--- a/luminoth/tasks.py
+++ b/luminoth/tasks.py
@@ -33,7 +33,8 @@ class Detector(object):
         """Instantiate a detector object with the appropriate config.
 
         Arguments:
-            checkpoint (str): Checkpoint name to instantiate the detector as.
+            checkpoint (str): Checkpoint id or alias to instantiate the
+                detector as.
             config (dict): Configuration parameters describing the desired
                 model. See `get_config` to load a config file.
 
@@ -142,8 +143,9 @@ class Detector(object):
         else:
             classes = set(classes)
 
-        # TODO: Remove the loop. Neither Faster R-CNN nor SSD support batch
-        # size yet, so it's the same for now.
+        # TODO: Remove the loop once (and if) we implement batch sizes. Neither
+        # Faster R-CNN nor SSD support batch size yet, so it's the same for
+        # now.
         predictions = []
         for image in images:
             predictions.append([

--- a/luminoth/tasks.py
+++ b/luminoth/tasks.py
@@ -1,0 +1,157 @@
+"""Module where all generic task models are located.
+
+Each class corresponds to a different task, providing a task-specific API for
+ease of use. This API is common among different implementations, abstracting
+away the pecularities of each task model. Thus, no knowledge of the inner
+workings of said models should be needed to use any of these classes.
+"""
+from luminoth.tools.checkpoint import get_checkpoint_config
+from luminoth.utils.predicting import PredictorNetwork
+
+
+class Detector(object):
+    """Encapsulates an object detection model behavior.
+
+    In order to perform object detection with a model implemented within
+    Luminoth, this class should be used.
+
+    Attributes:
+        classes (list of str): Ordered class names for the detector.
+        prob (float): Default probability threshold for predictions.
+
+    TODO:
+        - Don't create a TF session internally (or make its creation optional)
+          in order to be compatible with both TF-Eager and Jupyter Notebooks.
+        - Manage multiple instantiations correctly in order to avoid creating
+          the same TF objects over and over (which appends the `_N` suffix to
+          the graph and makes the checkpoint loading fail).
+    """
+
+    DEFAULT_CHECKPOINT = 'accurate'
+
+    def __init__(self, checkpoint=None, config=None, prob=0.7, classes=None):
+        """Instantiate a detector object with the appropriate config.
+
+        Arguments:
+            checkpoint (str): Checkpoint name to instantiate the detector as.
+            config (dict): Configuration parameters describing the desired
+                model. See `get_config` to load a config file.
+
+        Note:
+            Only one of the parameters must be specified. If none is, we
+            default to loading the checkpoint indicated by
+            `DEFAULT_CHECKPOINT`.
+        """
+        if checkpoint is not None and config is not None:
+            raise ValueError(
+                'Only one of `checkpoint` or `config` must be specified in '
+                'order to instantiate a Detector.'
+            )
+
+        if checkpoint is None and config is None:
+            # Neither checkpoint no config specified, default to
+            # `DEFAULT_CHECKPOINT`.
+            checkpoint = self.DEFAULT_CHECKPOINT
+
+        if checkpoint:
+            config = get_checkpoint_config(checkpoint)
+
+        # Prevent the model itself from filtering its proposals (default
+        # value of 0.5 is in use in the configs).
+        # TODO: A model should always return all of its predictions. The
+        # filtering should be done (if at all) by PredictorNetwork.
+        if config.model.type == 'fasterrcnn':
+            config.model.rcnn.proposals.min_prob_threshold = 0.0
+        elif config.model.type == 'ssd':
+            config.model.proposals.min_prob_threshold = 0.0
+
+        # TODO: Remove dependency on `PredictorNetwork` or clearly separate
+        # responsibilities.
+        self._network = PredictorNetwork(config)
+
+        self.prob = prob
+
+        # Use the labels when available, integers when not.
+        self._model_classes = (
+            self._network.class_labels if self._network.class_labels
+            else list(range(config.model.network.num_classes))
+        )
+        if classes:
+            self.classes = set(classes)
+            if not set(self._model_classes).issuperset(self.classes):
+                raise ValueError(
+                    '`classes` must be contained in the detector\'s classes. '
+                    'Available classes are: {}.'.format(self._model_classes)
+                )
+        else:
+            self.classes = set(self._model_classes)
+
+    def predict(self, images, prob=None, classes=None):
+        """Run the detector through a set of images.
+
+        Arguments:
+            images (numpy.ndarray or list): Either array of dimensions
+                `(height, width, channels)` (single image) or array of
+                dimensions `(number_of_images, height, width, channels)`
+                (multiple images). If a list, must be a list of rank 3 arrays.
+            prob (float): Override configured probability threshold for
+                predictions.
+            classes (set of str): Override configured class names to consider.
+
+        Returns:
+            Either list of objects detected in the image (single image case) or
+            list of list of objects detected (multiple images case).
+
+            In the multiple images case, the outer list has `number_of_images`
+            elements, while the inner ones have the number of objects detected
+            in each image.
+
+            Each object has the format::
+
+                {
+                    'bbox': [x_min, y_min, x_max, y_max],
+                    'label': '<cat|dog|person|...>' | 0..C,
+                    'prob': prob
+                }
+
+            The coordinates are integers, where `(x_min, y_min)` are the
+            coordinates of the top-left corner of the bounding box, while
+            `(x_max, y_max)` the bottom-right. By convention, the top-left
+            corner of the image is coordinate `(0, 0)`.
+
+            The probability, `prob`, is a float between 0 and 1, indicating the
+            confidence of the detection being correct.
+
+            The label of the object, `label`, may be either a string if the
+            classes file for the model is found or an integer between 0 and the
+            number of classes `C`.
+
+        """
+        # If it's a single image (ndarray of rank 3), turn into a list.
+        single_image = False
+        if not isinstance(images, list):
+            if len(images.shape) == 3:
+                images = [images]
+                single_image = True
+
+        if prob is None:
+            prob = self.prob
+
+        if classes is None:
+            classes = self.classes
+        else:
+            classes = set(classes)
+
+        # TODO: Remove the loop. Neither Faster R-CNN nor SSD support batch
+        # size yet, so it's the same for now.
+        predictions = []
+        for image in images:
+            predictions.append([
+                pred for pred in self._network.predict_image(image)
+                if pred['prob'] >= prob and pred['label'] in classes
+            ])
+
+        if single_image:
+            predictions = predictions[0]
+
+        return predictions

--- a/luminoth/vis.py
+++ b/luminoth/vis.py
@@ -1,0 +1,169 @@
+"""Provides various visualization-specific functions."""
+import numpy as np
+import sys
+
+from PIL import Image, ImageDraw, ImageFont
+
+
+def get_font():
+    """Attempts to retrieve a reasonably-looking TTF font from the system.
+
+    We don't make much of an effort, but it's what we can reasonably do without
+    incorporating additional dependencies for this task.
+    """
+    if sys.platform == 'win32':
+        font_names = ['Arial']
+    elif sys.platform in ['linux', 'linux2']:
+        font_names = ['DejaVuSans-Bold', 'DroidSans-Bold']
+    elif sys.platform == 'darwin':
+        font_names = ['Menlo', 'Helvetica']
+
+    font = None
+    for font_name in font_names:
+        try:
+            font = ImageFont.truetype(font_name)
+            break
+        except IOError:
+            continue
+
+    return font
+
+
+SYSTEM_FONT = get_font()
+
+
+def hex_to_rgb(x):
+    """Turns a color hex representation into a tuple representation."""
+    return tuple([int(x[i:i + 2], 16) for i in (0, 2, 4)])
+
+
+def build_colormap():
+    """Builds a colormap function that maps labels to colors.
+
+    Returns:
+        Function that receives a label and returns a color tuple `(R, G, B)`
+        for said label.
+    """
+    # Build the 10-color palette to be used for all classes. The following are
+    # the hex-codes for said colors (taken the default 10-categorical d3 color
+    # palette).
+    palette = (
+        '1f77b4ff7f0e2ca02cd627289467bd8c564be377c27f7f7fbcbd2217becf'
+    )
+    colors = [hex_to_rgb(palette[i:i + 6]) for i in range(0, len(palette), 6)]
+
+    seen_labels = {}
+
+    def colormap(label):
+        # If label not yet seen, get the next value in the palette sequence.
+        if label not in seen_labels:
+            seen_labels[label] = colors[len(seen_labels) % len(colors)]
+
+        return seen_labels[label]
+
+    return colormap
+
+
+def draw_rectangle(draw, coordinates, color, width=1):
+    """Draw a rectangle with an optional width."""
+    # Add alphas to the color so we have a small overlay over the object.
+    fill = color + (30,)
+    outline = color + (255,)
+
+    # Pillow doesn't support width in rectangles, so we must emulate it with a
+    # loop.
+    for i in range(width):
+        coords = [
+            coordinates[0] - i,
+            coordinates[1] - i,
+            coordinates[2] + i,
+            coordinates[3] + i,
+        ]
+
+        # Fill must be drawn only for the first rectangle, or the alphas will
+        # add up.
+        if i == 0:
+            draw.rectangle(coords, fill=fill, outline=outline)
+        else:
+            draw.rectangle(coords, outline=outline)
+
+
+def draw_label(draw, coords, color, label, prob):
+    """Draw a box with the label and probability."""
+    # Attempt to get a native TTF font. If not, use the default bitmap font.
+    global SYSTEM_FONT
+    if SYSTEM_FONT:
+        label_font = SYSTEM_FONT.font_variant(size=16)
+        prob_font = SYSTEM_FONT.font_variant(size=12)
+    else:
+        label_font = ImageFont.load_default()
+        prob_font = ImageFont.load_default()
+
+    label = str(label)  # `label` may not be a string.
+    prob = '({:.2f})'.format(prob)  # Turn `prob` into a string.
+
+    # We want the probability font to be smaller, so we'll write the label in
+    # two steps.
+    label_w, label_h = label_font.getsize(label)
+    prob_w, prob_h = prob_font.getsize(prob)
+
+    # Get margins to manually adjust the spacing. The margin goes between each
+    # segment (i.e. margin, label, margin, prob, margin).
+    margin_w, margin_h = label_font.getsize('M')
+    margin_w *= 0.2
+    _, full_line_height = label_font.getsize('Mq')
+
+    # Draw the background first, considering all margins and the full line
+    # height.
+    background_coords = [
+        coords[0],
+        coords[1],
+        coords[0] + label_w + prob_w + 3 * margin_w,
+        coords[1] + full_line_height * 1.15,
+    ]
+    draw.rectangle(background_coords, fill=color + (255,))
+
+    # Then write the two pieces of text.
+    draw.text([
+        coords[0] + margin_w,
+        coords[1],
+    ], label, font=label_font)
+
+    draw.text([
+        coords[0] + label_w + 2 * margin_w,
+        coords[1] + (margin_h - prob_h),
+    ], prob, font=prob_font)
+
+
+def vis_objects(image, objects, colormap=None, labels=True):
+    """Visualize objects as returned by `Detector`.
+
+    Arguments:
+        image (numpy.ndarray): Image to draw the bounding boxes on.
+        objects (list of dicts or dict): List of objects as returned by a
+            `Detector` instance.
+        colormap (function): Colormap function to use for the objects.
+        labels (boolean): Whether to draw labels.
+
+    Returns:
+        A PIL image with the detected objects' bounding boxes and labels drawn.
+        Can be casted to a `numpy.ndarray` by using `numpy.array` on the
+        returned object.
+    """
+    if not isinstance(objects, list):
+        objects = [objects]
+
+    if colormap is None:
+        colormap = build_colormap()
+
+    image = Image.fromarray(image.astype(np.uint8))
+
+    draw = ImageDraw.Draw(image, 'RGBA')
+    for obj in objects:
+        # TODO: Can we do image resolution-agnostic?
+        color = colormap(obj['label'])
+        draw_rectangle(draw, obj['bbox'], color, width=3)
+        if labels:
+            draw_label(draw, obj['bbox'][:2], color, obj['label'], obj['prob'])
+
+    return image


### PR DESCRIPTION
Adds several utility functions to ease the use of Luminoth through Python:
* `Detector` (in `luminoth.tasks`) to abstract the usage of object detection.
* `vis_objects` to visualize the results by drawing the bounding boxes in the image.
* `read_image` to read images from disk without needing to know about Pillow.

With this, the following is now possible:
```python
from luminoth import Detector, read_image, vis_objects

image = read_image('cat.png')

# Assumes `accurate` checkpoint by default. Other checkpoint, or a config object,
# can be specified.           
detector = Detector()
objects = detector.predict(image)

print(objects)

vis_objects(image, objects).save('cat-out.png')
```

Further work is required along the following lines:
* I/O functions to read batchs of frames out of a video.
* Remove the TODOs in `Detector` that depend on rewriting `PredictorNetwork`.
* Provide a way to access the detected objects' embeddings for further processing.
* Document the new API.
* Add examples on processing both images and videos.