### PR TITLE
Dataset readers improvements

### DIFF
--- a/docs/usage/dataset.rst
+++ b/docs/usage/dataset.rst
@@ -70,10 +70,13 @@ classes present in it, cars, trucks, buses and motorcycles. You can do so with
 the ``--only-classes`` option, by passing a comma-separated list of classes to
 keep in the final dataset.
 
-During development, it is often useful to verify that the model can actually
-overfit a small dataset. You can use the ``--limit-examples`` and
-``--limit-classes`` options for this, allowing you to create a dataset limited
-to up to ``N`` examples and/or ``M`` random classes.
+Moreover, if you wish to use several classes but not the entire set of images
+available in a (possibly large) dataset, you may use the ``--max-per-class``
+option.
+
+During development, it is often useful to verify that the model can actually overfit a
+small dataset. You can create such a dataset by using a small number for
+``--max-per-class``, and using it together with the ``--only-classes`` option.
 
 Examples
 ^^^^^^^^

--- a/docs/usage/dataset.rst
+++ b/docs/usage/dataset.rst
@@ -71,12 +71,11 @@ the ``--only-classes`` option, by passing a comma-separated list of classes to
 keep in the final dataset.
 
 Moreover, if you wish to use several classes but not the entire set of images
-available in a (possibly large) dataset, you may use the ``--max-per-class``
+available in a (possibly large) dataset, you may use the ``--class-examples``
 option.
 
 During development, it is often useful to verify that the model can actually overfit a
-small dataset. You can create such a dataset by using a small number for
-``--max-per-class``, and using it together with the ``--only-classes`` option.
+small dataset. You can create such a dataset by using the ``--limit-examples`` option.
 
 Examples
 ^^^^^^^^

--- a/luminoth/predict.py
+++ b/luminoth/predict.py
@@ -176,7 +176,7 @@ def predict_video(network, path, only_classes=None, ignore_classes=None,
 @click.option('config_files', '--config', '-c', multiple=True, help='Config to use.')  # noqa
 @click.option('--checkpoint', help='Checkpoint to use.')
 @click.option('override_params', '--override', '-o', multiple=True, help='Override model config params.')  # noqa
-@click.option('output_path', '--output', '-f', default='-', help='Output file.')  # noqa
+@click.option('output_path', '--output', '-f', default='-', help='Output file with the predictions (for example, JSON bounding boxes).')  # noqa
 @click.option('--save-media-to', '-d', help='Directory to store media to.')
 @click.option('--min-prob', default=0.5, type=float, help='When drawing, only draw bounding boxes with probability larger than.')  # noqa
 @click.option('--max-detections', default=100, type=int, help='Maximum number of detections per image.')  # noqa

--- a/luminoth/tools/dataset/readers/object_detection/coco.py
+++ b/luminoth/tools/dataset/readers/object_detection/coco.py
@@ -54,6 +54,10 @@ class COCOReader(ObjectDetectionReader):
             except ValueError:
                 continue
 
+            if self._should_skip(label=annotation_class):
+                continue
+            self._per_class_counter[annotation_class] += 1
+
             self._image_to_bboxes.setdefault(image_id, []).append({
                 'xmin': x,
                 'ymin': y,
@@ -87,15 +91,15 @@ class COCOReader(ObjectDetectionReader):
             if self._stop_iteration():
                 return
 
-            if not self._is_valid(image_id):
-                continue
-
             filename = image_details['file_name']
             width = image_details['width']
             height = image_details['height']
 
             gt_boxes = self._image_to_bboxes.get(image_id, [])
             if len(gt_boxes) == 0:
+                continue
+
+            if self._should_skip(image_id=image_id):
                 continue
 
             # Read the image *after* checking whether any ground truth box is

--- a/luminoth/tools/dataset/readers/object_detection/coco.py
+++ b/luminoth/tools/dataset/readers/object_detection/coco.py
@@ -54,8 +54,6 @@ class COCOReader(ObjectDetectionReader):
             except ValueError:
                 continue
 
-            if self._should_skip(label=annotation_class):
-                continue
             self._per_class_counter[annotation_class] += 1
 
             self._image_to_bboxes.setdefault(image_id, []).append({
@@ -99,7 +97,7 @@ class COCOReader(ObjectDetectionReader):
             if len(gt_boxes) == 0:
                 continue
 
-            if self._should_skip(image_id=image_id):
+            if self._should_skip(image_id):
                 continue
 
             # Read the image *after* checking whether any ground truth box is
@@ -114,9 +112,7 @@ class COCOReader(ObjectDetectionReader):
                 self.errors += 1
                 continue
 
-            self.yielded_records += 1
-
-            yield {
+            record = {
                 'width': width,
                 'height': height,
                 'depth': 3,
@@ -124,6 +120,10 @@ class COCOReader(ObjectDetectionReader):
                 'image_raw': image,
                 'gt_boxes': gt_boxes,
             }
+            self._will_add_record(record)
+            self.yielded_records += 1
+
+            yield record
 
     def _get_annotations_path(self):
         filename = 'instances_{}{}.json'.format(self._split, self._year)

--- a/luminoth/tools/dataset/readers/object_detection/coco.py
+++ b/luminoth/tools/dataset/readers/object_detection/coco.py
@@ -54,8 +54,6 @@ class COCOReader(ObjectDetectionReader):
             except ValueError:
                 continue
 
-            self._per_class_counter[annotation_class] += 1
-
             self._image_to_bboxes.setdefault(image_id, []).append({
                 'xmin': x,
                 'ymin': y,

--- a/luminoth/tools/dataset/readers/object_detection/csv_reader.py
+++ b/luminoth/tools/dataset/readers/object_detection/csv_reader.py
@@ -79,7 +79,7 @@ class CSVReader(ObjectDetectionReader):
             if self._stop_iteration():
                 return
 
-            if self._should_skip(image_id=image_id):
+            if self._should_skip(image_id):
                 continue
 
             image_path = self._get_image_path(image_id)
@@ -123,8 +123,6 @@ class CSVReader(ObjectDetectionReader):
                     ))
                     continue
 
-                if self._should_skip(label=label_id):
-                    continue
                 self._per_class_counter[label_id] += 1
 
                 gt_boxes.append({
@@ -138,9 +136,7 @@ class CSVReader(ObjectDetectionReader):
             if len(gt_boxes) == 0:
                 continue
 
-            self.yielded_records += 1
-
-            yield {
+            record = {
                 'width': width,
                 'height': height,
                 'depth': 3,
@@ -148,6 +144,10 @@ class CSVReader(ObjectDetectionReader):
                 'image_raw': image,
                 'gt_boxes': gt_boxes,
             }
+            self._will_add_record(record)
+            self.yielded_records += 1
+
+            yield record
 
     def _get_records(self):
         with tf.gfile.Open(self._labels_filename) as label_file:

--- a/luminoth/tools/dataset/readers/object_detection/csv_reader.py
+++ b/luminoth/tools/dataset/readers/object_detection/csv_reader.py
@@ -123,8 +123,6 @@ class CSVReader(ObjectDetectionReader):
                     ))
                     continue
 
-                self._per_class_counter[label_id] += 1
-
                 gt_boxes.append({
                     'label': label_id,
                     'xmin': b['xmin'],

--- a/luminoth/tools/dataset/readers/object_detection/flat_reader.py
+++ b/luminoth/tools/dataset/readers/object_detection/flat_reader.py
@@ -109,8 +109,6 @@ class FlatReader(ObjectDetectionReader):
                 except ValueError:
                     continue
 
-                self._per_class_counter[label_id] += 1
-
                 gt_boxes.append({
                     'label': label_id,
                     'xmin': b[self._x_min_key],

--- a/luminoth/tools/dataset/readers/object_detection/flat_reader.py
+++ b/luminoth/tools/dataset/readers/object_detection/flat_reader.py
@@ -83,7 +83,7 @@ class FlatReader(ObjectDetectionReader):
 
             image_id = annotation['image_id']
 
-            if self._should_skip(image_id=image_id):
+            if self._should_skip(image_id):
                 continue
 
             try:
@@ -109,8 +109,6 @@ class FlatReader(ObjectDetectionReader):
                 except ValueError:
                     continue
 
-                if self._should_skip(label=label_id):
-                    continue
                 self._per_class_counter[label_id] += 1
 
                 gt_boxes.append({
@@ -127,9 +125,7 @@ class FlatReader(ObjectDetectionReader):
                 self.errors += 1
                 continue
 
-            self.yielded_records += 1
-
-            yield {
+            record = {
                 'width': width,
                 'height': height,
                 'depth': 3,
@@ -137,6 +133,10 @@ class FlatReader(ObjectDetectionReader):
                 'image_raw': image,
                 'gt_boxes': gt_boxes,
             }
+            self._will_add_record(record)
+            self.yielded_records += 1
+
+            yield record
 
     @property
     def annotations(self):

--- a/luminoth/tools/dataset/readers/object_detection/flat_reader.py
+++ b/luminoth/tools/dataset/readers/object_detection/flat_reader.py
@@ -83,7 +83,7 @@ class FlatReader(ObjectDetectionReader):
 
             image_id = annotation['image_id']
 
-            if not self._is_valid(image_id):
+            if self._should_skip(image_id=image_id):
                 continue
 
             try:
@@ -108,6 +108,10 @@ class FlatReader(ObjectDetectionReader):
                     )
                 except ValueError:
                     continue
+
+                if self._should_skip(label=label_id):
+                    continue
+                self._per_class_counter[label_id] += 1
 
                 gt_boxes.append({
                     'label': label_id,

--- a/luminoth/tools/dataset/readers/object_detection/imagenet.py
+++ b/luminoth/tools/dataset/readers/object_detection/imagenet.py
@@ -50,7 +50,7 @@ class ImageNetReader(ObjectDetectionReader):
             if self._stop_iteration():
                 return
 
-            if self._should_skip(image_id=image_id):
+            if self._should_skip(image_id):
                 continue
 
             try:
@@ -92,8 +92,6 @@ class ImageNetReader(ObjectDetectionReader):
                     new_width=width, new_height=height
                 )
 
-                if self._should_skip(label=label_id):
-                    continue
                 self._per_class_counter[label_id] += 1
 
                 gt_boxes.append({
@@ -107,9 +105,7 @@ class ImageNetReader(ObjectDetectionReader):
             if len(gt_boxes) == 0:
                 continue
 
-            self.yielded_records += 1
-
-            yield {
+            record = {
                 'width': width,
                 'height': height,
                 'depth': 3,
@@ -117,6 +113,11 @@ class ImageNetReader(ObjectDetectionReader):
                 'image_raw': image,
                 'gt_boxes': gt_boxes,
             }
+
+            self._will_add_record(record)
+            self.yielded_records += 1
+
+            yield record
 
     def _validate_structure(self):
         if not tf.gfile.Exists(self._data_dir):

--- a/luminoth/tools/dataset/readers/object_detection/imagenet.py
+++ b/luminoth/tools/dataset/readers/object_detection/imagenet.py
@@ -50,7 +50,7 @@ class ImageNetReader(ObjectDetectionReader):
             if self._stop_iteration():
                 return
 
-            if not self._is_valid(image_id):
+            if self._should_skip(image_id=image_id):
                 continue
 
             try:
@@ -91,6 +91,10 @@ class ImageNetReader(ObjectDetectionReader):
                     old_height=int(annotation['size']['height']),
                     new_width=width, new_height=height
                 )
+
+                if self._should_skip(label=label_id):
+                    continue
+                self._per_class_counter[label_id] += 1
 
                 gt_boxes.append({
                     'label': label_id,

--- a/luminoth/tools/dataset/readers/object_detection/imagenet.py
+++ b/luminoth/tools/dataset/readers/object_detection/imagenet.py
@@ -92,8 +92,6 @@ class ImageNetReader(ObjectDetectionReader):
                     new_width=width, new_height=height
                 )
 
-                self._per_class_counter[label_id] += 1
-
                 gt_boxes.append({
                     'label': label_id,
                     'xmin': xmin,

--- a/luminoth/tools/dataset/readers/object_detection/object_detection_reader.py
+++ b/luminoth/tools/dataset/readers/object_detection/object_detection_reader.py
@@ -1,5 +1,4 @@
 import abc
-import random
 import six
 
 from luminoth.tools.dataset.readers import BaseReader

--- a/luminoth/tools/dataset/readers/object_detection/object_detection_reader.py
+++ b/luminoth/tools/dataset/readers/object_detection/object_detection_reader.py
@@ -57,10 +57,14 @@ class ObjectDetectionReader(BaseReader):
             self._classes = self.get_classes()
         return self._classes
 
+    @classes.setter
+    def classes(self, classes):
+        self._classes = classes
+
     @abc.abstractmethod
     def get_total(self):
         """
-        Returns the total amount of records in the dataset.
+        Returns the total number of records in the dataset.
         """
 
     @abc.abstractmethod
@@ -129,6 +133,3 @@ class ObjectDetectionReader(BaseReader):
                     xmax (int): x value for bottom-right point.
                     ymax (int): y value for bottom-right point.
         """
-
-    def set_classes(self, classes):
-        self._classes = classes

--- a/luminoth/tools/dataset/readers/object_detection/object_detection_reader.py
+++ b/luminoth/tools/dataset/readers/object_detection/object_detection_reader.py
@@ -29,14 +29,16 @@ class ObjectDetectionReader(BaseReader):
     number of examples per class in an efficient way.
     """
     def __init__(self, only_classes=None, only_images=None,
-                 max_per_class=None, **kwargs):
+                 limit_examples=None, max_per_class=None, **kwargs):
         """
         Args:
             - only_classes: string or list of strings used as a class
                 whitelist.
             - only_images: string or list of strings used as a image_id
                 whitelist.
-            - max_per_class: max number of examples to use per class.
+            - limit_examples: max number of examples (images) to use.
+            - max_per_class: finish when every class has this approximate
+                number of examples.
         """
         super(ObjectDetectionReader, self).__init__()
         if isinstance(only_classes, six.string_types):
@@ -52,6 +54,7 @@ class ObjectDetectionReader(BaseReader):
         self._total = None
         self._classes = None
 
+        self._limit_examples = limit_examples
         self._max_per_class = max_per_class
         self._per_class_counter = Counter()
         self._maxed_out_classes = set()
@@ -98,6 +101,9 @@ class ObjectDetectionReader(BaseReader):
         """
         if self._only_images:  # not None and not empty
             return len(self._only_images)
+
+        if self._limit_examples is not None and self._limit_examples > 0:
+            return min(self._limit_examples, original_total_records)
 
         # With _max_per_class we potentially have to iterate over every record,
         # so we don't know the total ahead of time.

--- a/luminoth/tools/dataset/readers/object_detection/object_detection_reader.py
+++ b/luminoth/tools/dataset/readers/object_detection/object_detection_reader.py
@@ -139,13 +139,19 @@ class ObjectDetectionReader(BaseReader):
 
         return False
 
+    def _all_maxed_out(self):
+        # Every class is maxed out
+        if self._class_examples is not None:
+            return len(self._maxed_out_classes) == len(self.classes)
+
+        return False
+
     def _stop_iteration(self):
         if self.yielded_records == self.total:
             return True
 
-        # Every class is maxed out
-        if self._class_examples is not None:
-            return len(self._maxed_out_classes) == len(self.classes)
+        if self._all_maxed_out():
+            return True
 
         return False
 

--- a/luminoth/tools/dataset/readers/object_detection/object_detection_reader.py
+++ b/luminoth/tools/dataset/readers/object_detection/object_detection_reader.py
@@ -6,21 +6,19 @@ from luminoth.tools.dataset.readers import BaseReader
 
 
 class ObjectDetectionReader(BaseReader):
-    """Reads data suitable for object detection.
+    """
+    Reads data suitable for object detection.
 
-    Object detections needs:
-        - images
-        - gt_boxes with labels
+    The object detection task needs the following information:
+        - images.
+        - ground truth, rectangular bounding boxes with associated labels.
 
-    For implementing a subclass of object detection one needs to implement the
-    following methods:
-        - __init__(data_dir, split, **kwargs)
-        - get_total(self)
-            Get total amount of records.
-        - get_classes(self)
-            Get all classes in records.
-        - iterate(self)
-            Iterate over all records.
+    For implementing a subclass of object detection, one needs to implement
+    the following methods:
+        - __init__
+        - get_total
+        - get_classes
+        - iterate
     """
     def __init__(self, only_classes=None, only_images=None,
                  limit_examples=None, **kwargs):

--- a/luminoth/tools/dataset/readers/object_detection/object_detection_reader.py
+++ b/luminoth/tools/dataset/readers/object_detection/object_detection_reader.py
@@ -23,7 +23,7 @@ class ObjectDetectionReader(BaseReader):
             Iterate over all records.
     """
     def __init__(self, only_classes=None, only_images=None,
-                 limit_examples=None, limit_classes=None, seed=None, **kwargs):
+                 limit_examples=None, **kwargs):
         """
         Args:
             - only_classes: string or list of strings used as a class
@@ -31,8 +31,6 @@ class ObjectDetectionReader(BaseReader):
             - only_images: string or list of strings used as a image_id
                 whitelist.
             - limit_examples: limit number of examples to use.
-            - limit_classes: limit number of classes to use.
-            - seed: seed for random.
         """
         super(ObjectDetectionReader, self).__init__()
         if isinstance(only_classes, six.string_types):
@@ -46,9 +44,6 @@ class ObjectDetectionReader(BaseReader):
         self._only_images = only_images
 
         self._limit_examples = limit_examples
-        self._limit_classes = limit_classes
-        random.seed(seed)
-
         self._total = None
         self._classes = None
 
@@ -66,16 +61,19 @@ class ObjectDetectionReader(BaseReader):
 
     @abc.abstractmethod
     def get_total(self):
-        """Returns the total amount of records in the dataset.
+        """
+        Returns the total amount of records in the dataset.
         """
 
     @abc.abstractmethod
     def get_classes(self):
-        """Returns all the classes available in the dataset.
+        """
+        Returns all the classes available in the dataset.
         """
 
     def _filter_total(self, original_total_records):
-        """Filters total number of records in dataset based on reader options
+        """
+        Filters total number of records in dataset based on reader options
         used.
         """
         # Define smaller number of records when limiting examples.
@@ -89,16 +87,11 @@ class ObjectDetectionReader(BaseReader):
         return new_total
 
     def _filter_classes(self, original_classes):
-        """Filters classes based on reader options used.
+        """
+        Filters classes based on reader options used.
         """
         if self._only_classes:  # not None and not empty
             new_classes = sorted(self._only_classes)
-        # Choose random classes when limiting them
-        elif self._limit_classes is not None and self._limit_classes > 0:
-            total_classes = min(len(original_classes), self._limit_classes)
-            new_classes = sorted(
-                random.sample(original_classes, total_classes)
-            )
         else:
             new_classes = list(original_classes) if original_classes else None
 
@@ -121,7 +114,8 @@ class ObjectDetectionReader(BaseReader):
 
     @abc.abstractmethod
     def iterate(self):
-        """Iterate over object detection records read from the dataset source.
+        """
+        Iterate over object detection records read from the dataset source.
 
         Returns:
             iterator of records of type `dict` with the following keys:

--- a/luminoth/tools/dataset/readers/object_detection/openimages.py
+++ b/luminoth/tools/dataset/readers/object_detection/openimages.py
@@ -165,6 +165,10 @@ class OpenImagesReader(ObjectDetectionReader):
                 if not self._is_valid(line['ImageID']):
                     continue
 
+                # Filter group annotations (we only want single instances)
+                if line['IsGroupOf'] == '1':
+                    continue
+
                 if line['ImageID'] != current_image_id:
                     # Yield if image changes and we have current image.
                     if current_image_id is not None:
@@ -174,7 +178,6 @@ class OpenImagesReader(ObjectDetectionReader):
                             tf.logging.debug(
                                 'Dropping record {} without gt_boxes.'.format(
                                     partial_record))
-                            pass
 
                     # Start new record.
                     current_image_id = line['ImageID']

--- a/luminoth/tools/dataset/readers/object_detection/openimages.py
+++ b/luminoth/tools/dataset/readers/object_detection/openimages.py
@@ -162,7 +162,7 @@ class OpenImagesReader(ObjectDetectionReader):
                 if self._stop_iteration():
                     break
 
-                if not self._is_valid(line['ImageID']):
+                if self._should_skip(image_id=line['ImageID']):
                     continue
 
                 # Filter group annotations (we only want single instances)
@@ -194,6 +194,10 @@ class OpenImagesReader(ObjectDetectionReader):
                     label = self.trainable_labels.index(line['LabelName'])
                 except ValueError:
                     continue
+
+                if self._should_skip(label=label):
+                    continue
+                self._per_class_counter[label] += 1
 
                 partial_record['gt_boxes'].append({
                     'xmin': float(line['XMin']),

--- a/luminoth/tools/dataset/readers/object_detection/openimages.py
+++ b/luminoth/tools/dataset/readers/object_detection/openimages.py
@@ -237,7 +237,9 @@ class OpenImagesReader(ObjectDetectionReader):
                 })
 
             else:
-                self._queue_record(records_queue, partial_record)
+                # No data we care about in dataset -- nothing to queue
+                if partial_record:
+                    self._queue_record(records_queue, partial_record)
 
         # Wait for all task to be consumed.
         records_queue.join()

--- a/luminoth/tools/dataset/readers/object_detection/openimages.py
+++ b/luminoth/tools/dataset/readers/object_detection/openimages.py
@@ -157,7 +157,7 @@ class OpenImagesReader(ObjectDetectionReader):
         # example, if "Persons" has been maxed out but "Bus" has not, a new
         # image containing only instances of "Person" will not be yielded,
         # while an image containing both "Person" and "Bus" instances will.
-        if self._max_per_class:
+        if self._class_examples:
             labels_in_image = set([
                 self.classes[bbox['label']] for bbox in record['gt_boxes']
             ])

--- a/luminoth/tools/dataset/readers/object_detection/openimages.py
+++ b/luminoth/tools/dataset/readers/object_detection/openimages.py
@@ -144,7 +144,7 @@ class OpenImagesReader(ObjectDetectionReader):
 
     def _queue_record(self, records_queue, record):
         if (self._limit_examples is not None and
-            self._total_queued >= self._limit_examples):
+                self._total_queued >= self._limit_examples):
             return
 
         if not record['gt_boxes']:

--- a/luminoth/tools/dataset/readers/object_detection/pascalvoc.py
+++ b/luminoth/tools/dataset/readers/object_detection/pascalvoc.py
@@ -1,4 +1,5 @@
 import os
+
 import tensorflow as tf
 
 from luminoth.tools.dataset.readers import InvalidDataDirectory
@@ -76,8 +77,7 @@ class PascalVOCReader(ObjectDetectionReader):
                 # Finish iteration.
                 return
 
-            if not self._is_valid(image_id):
-                # Ignore image when using image_id is not valid.
+            if self._should_skip(image_id=image_id):
                 continue
 
             try:
@@ -101,6 +101,10 @@ class PascalVOCReader(ObjectDetectionReader):
                     label_id = self.classes.index(b['name'])
                 except ValueError:
                     continue
+
+                if self._should_skip(label=label_id):
+                    continue
+                self._per_class_counter[label_id] += 1
 
                 gt_boxes.append({
                     'label': label_id,

--- a/luminoth/tools/dataset/readers/object_detection/pascalvoc.py
+++ b/luminoth/tools/dataset/readers/object_detection/pascalvoc.py
@@ -102,8 +102,6 @@ class PascalVOCReader(ObjectDetectionReader):
                 except ValueError:
                     continue
 
-                self._per_class_counter[label_id] += 1
-
                 gt_boxes.append({
                     'label': label_id,
                     'xmin': b['bndbox']['xmin'],

--- a/luminoth/tools/dataset/readers/object_detection/pascalvoc.py
+++ b/luminoth/tools/dataset/readers/object_detection/pascalvoc.py
@@ -77,7 +77,7 @@ class PascalVOCReader(ObjectDetectionReader):
                 # Finish iteration.
                 return
 
-            if self._should_skip(image_id=image_id):
+            if self._should_skip(image_id):
                 continue
 
             try:
@@ -102,8 +102,6 @@ class PascalVOCReader(ObjectDetectionReader):
                 except ValueError:
                     continue
 
-                if self._should_skip(label=label_id):
-                    continue
                 self._per_class_counter[label_id] += 1
 
                 gt_boxes.append({
@@ -117,9 +115,7 @@ class PascalVOCReader(ObjectDetectionReader):
             if len(gt_boxes) == 0:
                 continue
 
-            self.yielded_records += 1
-
-            yield {
+            record = {
                 'width': annotation['size']['width'],
                 'height': annotation['size']['height'],
                 'depth': annotation['size']['depth'],
@@ -127,3 +123,7 @@ class PascalVOCReader(ObjectDetectionReader):
                 'image_raw': image,
                 'gt_boxes': gt_boxes,
             }
+            self._will_add_record(record)
+            self.yielded_records += 1
+
+            yield record

--- a/luminoth/tools/dataset/readers/object_detection/taggerine.py
+++ b/luminoth/tools/dataset/readers/object_detection/taggerine.py
@@ -160,8 +160,6 @@ class TaggerineReader(ObjectDetectionReader):
                 except ValueError:
                     continue
 
-                self._per_class_counter[label_id] += 1
-
                 if 'height' in b and 'width' in b and 'x' in b and 'y' in b:
                     gt_boxes.append({
                         'label': label_id,

--- a/luminoth/tools/dataset/readers/object_detection/taggerine.py
+++ b/luminoth/tools/dataset/readers/object_detection/taggerine.py
@@ -134,7 +134,7 @@ class TaggerineReader(ObjectDetectionReader):
 
             image_id = annotation['image_id']
 
-            if self._should_skip(image_id=image_id):
+            if self._should_skip(image_id):
                 continue
 
             try:
@@ -160,8 +160,6 @@ class TaggerineReader(ObjectDetectionReader):
                 except ValueError:
                     continue
 
-                if self._should_skip(label=label_id):
-                    continue
                 self._per_class_counter[label_id] += 1
 
                 if 'height' in b and 'width' in b and 'x' in b and 'y' in b:
@@ -187,9 +185,7 @@ class TaggerineReader(ObjectDetectionReader):
                 self.errors += 1
                 continue
 
-            self.yielded_records += 1
-
-            yield {
+            record = {
                 'width': img_width,
                 'height': img_height,
                 'depth': 3,
@@ -197,3 +193,8 @@ class TaggerineReader(ObjectDetectionReader):
                 'image_raw': image,
                 'gt_boxes': gt_boxes,
             }
+
+            self._will_add_record(record)
+            self.yielded_records += 1
+
+            yield record

--- a/luminoth/tools/dataset/readers/object_detection/taggerine.py
+++ b/luminoth/tools/dataset/readers/object_detection/taggerine.py
@@ -134,8 +134,7 @@ class TaggerineReader(ObjectDetectionReader):
 
             image_id = annotation['image_id']
 
-            # Checks that the image is valid using the "only images" filter.
-            if not self._is_valid(image_id):
+            if self._should_skip(image_id=image_id):
                 continue
 
             try:
@@ -160,6 +159,10 @@ class TaggerineReader(ObjectDetectionReader):
                     )
                 except ValueError:
                     continue
+
+                if self._should_skip(label=label_id):
+                    continue
+                self._per_class_counter[label_id] += 1
 
                 if 'height' in b and 'width' in b and 'x' in b and 'y' in b:
                     gt_boxes.append({

--- a/luminoth/tools/dataset/transform.py
+++ b/luminoth/tools/dataset/transform.py
@@ -8,38 +8,30 @@ from .readers import get_reader, READERS
 from .writers import ObjectDetectionWriter
 
 
-def get_output_subfolder(only_classes, only_images, limit_examples,
-                         limit_classes):
+def get_output_subfolder(only_classes, only_images, limit_examples):
     """
-    Returns: subfolder name for records
+    Returns: subfolder name for records.
     """
     if only_classes is not None:
         return 'classes-{}'.format(only_classes.replace('/', ''))
     elif only_images is not None:
         return 'only-{}'.format(only_images)
-    elif limit_examples is not None and limit_classes is not None:
-        return 'limit-{}-classes-{}'.format(limit_examples, limit_classes)
     elif limit_examples is not None:
         return 'limit-{}'.format(limit_examples)
-    elif limit_classes is not None:
-        return 'classes-{}'.format(limit_classes)
 
 
 @click.command()
 @click.option('dataset_reader', '--type', type=click.Choice(READERS.keys()), required=True)  # noqa
 @click.option('--data-dir', required=True, help='Where to locate the original data.')  # noqa
 @click.option('--output-dir', required=True, help='Where to save the transformed data.')  # noqa
-@click.option('splits', '--split', required=True, multiple=True, help='Which splits to transform.')  # noqa
-@click.option('--only-classes', help='Whitelist of classes.')
-@click.option('--only-images', help='Create dataset with specific examples.')
-@click.option('--limit-examples', type=int, help='Limit dataset with to the first `N` examples.')  # noqa
-@click.option('--limit-classes', type=int, help='Limit dataset with `N` random classes.')  # noqa
-@click.option('--seed', type=int, help='Seed used for picking random classes.')
+@click.option('splits', '--split', required=True, multiple=True, help='The splits to transform (ie. train, test, val).')  # noqa
+@click.option('--only-classes', help='Keep only examples of these classes. Comma separated list.')  # noqa
+@click.option('--only-images', help='Create dataset with specific examples. Useful to test model if your model has the ability to overfit.')  # noqa
+@click.option('--limit-examples', type=int, help='Limit dataset with to the first global `N` examples (not per class).')  # noqa
 @click.option('overrides', '--override', '-o', multiple=True, help='Custom parameters for readers.')  # noqa
 @click.option('--debug', is_flag=True, help='Set level logging to DEBUG.')
 def transform(dataset_reader, data_dir, output_dir, splits, only_classes,
-              only_images, limit_examples, limit_classes, seed, overrides,
-              debug):
+              only_images, limit_examples, overrides, debug):
     """
     Prepares dataset for ingestion.
 
@@ -53,7 +45,7 @@ def transform(dataset_reader, data_dir, output_dir, splits, only_classes,
     # We forcefully save modified datasets into subfolders to avoid
     # overwriting and/or unnecessary clutter.
     output_subfolder = get_output_subfolder(
-        only_classes, only_images, limit_examples, limit_classes
+        only_classes, only_images, limit_examples
     )
     if output_subfolder:
         output_dir = os.path.join(output_dir, output_subfolder)
@@ -75,8 +67,7 @@ def transform(dataset_reader, data_dir, output_dir, splits, only_classes,
             split_reader = reader(
                 data_dir, split,
                 only_classes=only_classes, only_images=only_images,
-                limit_examples=limit_examples, limit_classes=limit_classes,
-                seed=seed, **reader_kwargs
+                limit_examples=limit_examples, **reader_kwargs
             )
 
             if classes is None:

--- a/luminoth/tools/dataset/transform.py
+++ b/luminoth/tools/dataset/transform.py
@@ -8,18 +8,6 @@ from .readers import get_reader, READERS
 from .writers import ObjectDetectionWriter
 
 
-def get_output_subfolder(only_classes, only_images, limit_examples):
-    """
-    Returns: subfolder name for records.
-    """
-    if only_classes is not None:
-        return 'classes-{}'.format(only_classes.replace('/', ''))
-    elif only_images is not None:
-        return 'only-{}'.format(only_images)
-    elif limit_examples is not None:
-        return 'limit-{}'.format(limit_examples)
-
-
 @click.command()
 @click.option('dataset_reader', '--type', type=click.Choice(READERS.keys()), required=True)  # noqa
 @click.option('--data-dir', required=True, help='Where to locate the original data.')  # noqa
@@ -37,18 +25,9 @@ def transform(dataset_reader, data_dir, output_dir, splits, only_classes,
 
     Converts the dataset into different (one per split) TFRecords files.
     """
+    tf.logging.set_verbosity(tf.logging.INFO)
     if debug:
         tf.logging.set_verbosity(tf.logging.DEBUG)
-    else:
-        tf.logging.set_verbosity(tf.logging.INFO)
-
-    # We forcefully save modified datasets into subfolders to avoid
-    # overwriting and/or unnecessary clutter.
-    output_subfolder = get_output_subfolder(
-        only_classes, only_images, limit_examples
-    )
-    if output_subfolder:
-        output_dir = os.path.join(output_dir, output_subfolder)
 
     try:
         reader = get_reader(dataset_reader)

--- a/luminoth/tools/dataset/transform.py
+++ b/luminoth/tools/dataset/transform.py
@@ -15,11 +15,11 @@ from .writers import ObjectDetectionWriter
 @click.option('--only-classes', help='Keep only examples of these classes. Comma separated list.')  # noqa
 @click.option('--only-images', help='Create dataset with specific examples. Useful to test model if your model has the ability to overfit.')  # noqa
 @click.option('--limit-examples', type=int, help='Limit the dataset to the first `N` examples.')  # noqa
-@click.option('--max-per-class', type=int, help='Finish when every class has at least `N` number of samples. This will be the attempted lower bound; more examples might be added or a class might finish with fewer samples depending on the dataset.')  # noqa
+@click.option('--class-examples', type=int, help='Finish when every class has at least `N` number of samples. This will be the attempted lower bound; more examples might be added or a class might finish with fewer samples depending on the dataset.')  # noqa
 @click.option('overrides', '--override', '-o', multiple=True, help='Custom parameters for readers.')  # noqa
 @click.option('--debug', is_flag=True, help='Set level logging to DEBUG.')
 def transform(dataset_reader, data_dir, output_dir, splits, only_classes,
-              only_images, limit_examples, max_per_class, overrides, debug):
+              only_images, limit_examples, class_examples, overrides, debug):
     """
     Prepares dataset for ingestion.
 
@@ -46,7 +46,7 @@ def transform(dataset_reader, data_dir, output_dir, splits, only_classes,
             split_reader = reader(
                 data_dir, split,
                 only_classes=only_classes, only_images=only_images,
-                limit_examples=limit_examples, max_per_class=max_per_class,
+                limit_examples=limit_examples, class_examples=class_examples,
                 **reader_kwargs
             )
 

--- a/luminoth/tools/dataset/transform.py
+++ b/luminoth/tools/dataset/transform.py
@@ -75,7 +75,7 @@ def transform(dataset_reader, data_dir, output_dir, splits, only_classes,
                 classes = split_reader.classes
             else:
                 # Overwrite classes after first split for consistency.
-                split_reader.set_classes(classes)
+                split_reader.classes = classes
 
             # We assume we are saving object detection objects, but it should
             # be easy to modify once we have different types of objects.

--- a/luminoth/tools/dataset/transform.py
+++ b/luminoth/tools/dataset/transform.py
@@ -15,7 +15,7 @@ from .writers import ObjectDetectionWriter
 @click.option('--only-classes', help='Keep only examples of these classes. Comma separated list.')  # noqa
 @click.option('--only-images', help='Create dataset with specific examples. Useful to test model if your model has the ability to overfit.')  # noqa
 @click.option('--limit-examples', type=int, help='Limit the dataset to the first `N` examples.')  # noqa
-@click.option('--max-per-class', type=int, help='Finish when every class has at least `N` number of samples. This will be the attempted lower bound; more examples might be added or a class might finish with less samples depending on the dataset.')  # noqa
+@click.option('--max-per-class', type=int, help='Finish when every class has at least `N` number of samples. This will be the attempted lower bound; more examples might be added or a class might finish with fewer samples depending on the dataset.')  # noqa
 @click.option('overrides', '--override', '-o', multiple=True, help='Custom parameters for readers.')  # noqa
 @click.option('--debug', is_flag=True, help='Set level logging to DEBUG.')
 def transform(dataset_reader, data_dir, output_dir, splits, only_classes,

--- a/luminoth/tools/dataset/transform.py
+++ b/luminoth/tools/dataset/transform.py
@@ -14,11 +14,12 @@ from .writers import ObjectDetectionWriter
 @click.option('splits', '--split', required=True, multiple=True, help='The splits to transform (ie. train, test, val).')  # noqa
 @click.option('--only-classes', help='Keep only examples of these classes. Comma separated list.')  # noqa
 @click.option('--only-images', help='Create dataset with specific examples. Useful to test model if your model has the ability to overfit.')  # noqa
-@click.option('--max-per-class', type=int, help='Finish when every class has at least `N` number of samples. This is an approximate lower bound (a few more examples might be added).')  # noqa
+@click.option('--limit-examples', type=int, help='Limit the dataset to the first `N` examples.')  # noqa
+@click.option('--max-per-class', type=int, help='Finish when every class has at least `N` number of samples. This will be the attempted lower bound; more examples might be added or a class might finish with less samples depending on the dataset.')  # noqa
 @click.option('overrides', '--override', '-o', multiple=True, help='Custom parameters for readers.')  # noqa
 @click.option('--debug', is_flag=True, help='Set level logging to DEBUG.')
 def transform(dataset_reader, data_dir, output_dir, splits, only_classes,
-              only_images, max_per_class, overrides, debug):
+              only_images, limit_examples, max_per_class, overrides, debug):
     """
     Prepares dataset for ingestion.
 
@@ -45,7 +46,8 @@ def transform(dataset_reader, data_dir, output_dir, splits, only_classes,
             split_reader = reader(
                 data_dir, split,
                 only_classes=only_classes, only_images=only_images,
-                max_per_class=max_per_class, **reader_kwargs
+                limit_examples=limit_examples, max_per_class=max_per_class,
+                **reader_kwargs
             )
 
             if classes is None:

--- a/luminoth/tools/dataset/transform.py
+++ b/luminoth/tools/dataset/transform.py
@@ -62,7 +62,7 @@ def transform(dataset_reader, data_dir, output_dir, splits, only_classes,
             writer = ObjectDetectionWriter(split_reader, output_dir, split)
             writer.save()
 
-            tf.logging.info('Dataset composition per class:')
+            tf.logging.info('Composition per class ({}):'.format(split))
             for label, count in split_reader._per_class_counter.most_common():
                 tf.logging.info(
                     '\t%s: %d', split_reader.pretty_name(label), count

--- a/luminoth/tools/dataset/transform.py
+++ b/luminoth/tools/dataset/transform.py
@@ -1,4 +1,3 @@
-import os
 import click
 import tensorflow as tf
 
@@ -15,11 +14,11 @@ from .writers import ObjectDetectionWriter
 @click.option('splits', '--split', required=True, multiple=True, help='The splits to transform (ie. train, test, val).')  # noqa
 @click.option('--only-classes', help='Keep only examples of these classes. Comma separated list.')  # noqa
 @click.option('--only-images', help='Create dataset with specific examples. Useful to test model if your model has the ability to overfit.')  # noqa
-@click.option('--limit-examples', type=int, help='Limit dataset with to the first global `N` examples (not per class).')  # noqa
+@click.option('--max-per-class', type=int, help='Limit to a maximum of `N` examples per class.')  # noqa
 @click.option('overrides', '--override', '-o', multiple=True, help='Custom parameters for readers.')  # noqa
 @click.option('--debug', is_flag=True, help='Set level logging to DEBUG.')
 def transform(dataset_reader, data_dir, output_dir, splits, only_classes,
-              only_images, limit_examples, overrides, debug):
+              only_images, max_per_class, overrides, debug):
     """
     Prepares dataset for ingestion.
 
@@ -46,7 +45,7 @@ def transform(dataset_reader, data_dir, output_dir, splits, only_classes,
             split_reader = reader(
                 data_dir, split,
                 only_classes=only_classes, only_images=only_images,
-                limit_examples=limit_examples, **reader_kwargs
+                max_per_class=max_per_class, **reader_kwargs
             )
 
             if classes is None:

--- a/luminoth/tools/dataset/transform.py
+++ b/luminoth/tools/dataset/transform.py
@@ -14,7 +14,7 @@ from .writers import ObjectDetectionWriter
 @click.option('splits', '--split', required=True, multiple=True, help='The splits to transform (ie. train, test, val).')  # noqa
 @click.option('--only-classes', help='Keep only examples of these classes. Comma separated list.')  # noqa
 @click.option('--only-images', help='Create dataset with specific examples. Useful to test model if your model has the ability to overfit.')  # noqa
-@click.option('--max-per-class', type=int, help='Limit to a maximum of `N` examples per class.')  # noqa
+@click.option('--max-per-class', type=int, help='Finish when every class has at least `N` number of samples. This is an approximate lower bound (a few more examples might be added).')  # noqa
 @click.option('overrides', '--override', '-o', multiple=True, help='Custom parameters for readers.')  # noqa
 @click.option('--debug', is_flag=True, help='Set level logging to DEBUG.')
 def transform(dataset_reader, data_dir, output_dir, splits, only_classes,
@@ -59,5 +59,12 @@ def transform(dataset_reader, data_dir, output_dir, splits, only_classes,
             # be easy to modify once we have different types of objects.
             writer = ObjectDetectionWriter(split_reader, output_dir, split)
             writer.save()
+
+            tf.logging.info('Dataset composition per class:')
+            for label, count in split_reader._per_class_counter.most_common():
+                tf.logging.info(
+                    '\t%s: %d', split_reader.pretty_name(label), count
+                )
+
     except InvalidDataDirectory as e:
         tf.logging.error('Error reading dataset: {}'.format(e))

--- a/luminoth/tools/dataset/writers/object_detection_writer.py
+++ b/luminoth/tools/dataset/writers/object_detection_writer.py
@@ -54,7 +54,11 @@ class ObjectDetectionWriter(BaseWriter):
 
         # Save classes in simple json format for later use.
         classes_file = os.path.join(self._output_dir, CLASSES_FILENAME)
-        json.dump(self._reader.classes, tf.gfile.GFile(classes_file, 'w'))
+        json.dump([
+            self._reader.pretty_name(label)
+            for label in self._reader.classes
+        ], tf.gfile.GFile(classes_file, 'w'))
+
         record_file = os.path.join(
             self._output_dir, '{}.tfrecords'.format(self._split))
         writer = tf.python_io.TFRecordWriter(record_file)


### PR DESCRIPTION
* Revamped CLI options.
  - Supports `lumi dataset transform --class-examples N`, which makes the dataset construction finish when every class has at least `N` number of samples. This will be the attempted lower bound; more examples might be added or a class might finish with fewer samples depending on the dataset.
  - Removed useless "random classes" options & seed.
* Fixed OpenImages reader.
  - Now works with correct folder structure.
  - Skips group annotations.
* Print dataset per-class composition after any `transform` command.