### PR TITLE
Improvements for the CSV reader

### DIFF
--- a/docs/usage/dataset.rst
+++ b/docs/usage/dataset.rst
@@ -41,6 +41,12 @@ The supported types are:
 - ``coco``: format used by the `COCO <http://cocodataset.org/#download>`_
   dataset.
 
+- ``openimages``: format used by the `OpenImages
+  <https://storage.googleapis.com/openimages/web/index.html>`_ dataset.
+
+- ``csv``: specify the bounding boxes using a CSV file with one
+  annotation per line.
+
 Input and output
 ^^^^^^^^^^^^^^^^
 

--- a/luminoth/tools/dataset/readers/object_detection/csv_reader.py
+++ b/luminoth/tools/dataset/readers/object_detection/csv_reader.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 import csv
 import os
 import six

--- a/luminoth/tools/dataset/readers/object_detection/openimages.py
+++ b/luminoth/tools/dataset/readers/object_detection/openimages.py
@@ -33,13 +33,13 @@ class OpenImagesReader(ObjectDetectionReader):
     def __init__(self, data_dir, split, download_threads=25, **kwargs):
         """
         Args:
-            - data_dir: Path to base directory where to find all the necessary
+            data_dir: Path to base directory where to find all the necessary
                 files and folders.
-            - split: Split to use, it is used for reading the appropiate
+            split: Split to use, it is used for reading the appropiate
                 annotations.
-            - download_threads: Number of threads to use for downloading
+            download_threads: Number of threads to use for downloading
                 images.
-            - only_classes: String with classes ids to be used as filter for
+            only_classes: String with classes ids to be used as filter for
                 all the available classes. If the string contains ',' it will
                 split the string using them.
         """


### PR DESCRIPTION
Fixes issues and adds better documentation.

`CSVReader` now accepts the following directory structure only:

```
.                  
├── train          
│   ├── image_1.jpg
│   ├── image_2.jpg
│   └── image_3.jpg
├── val            
│   ├── image_4.jpg
│   ├── image_5.jpg
│   └── image_6.jpg
├── train.csv      
└── val.csv
```

That is, a file named `{split}.csv` with the annotations and a directory named `{split}/` with the images. 

The annotation file expects the following format:
```
image_id,xmin,ymin,xmax,ymax,label
image_1.jpg,26,594,86,617,cat     
image_1.jpg,599,528,612,541,car   
image_2.jpg,393,477,430,552,dog   
```

The CSV header may be skipped by overriding the `headers` reader option (with `lumi dataset transform -o header=False`), in which case the `columns` option will be used (specified as comma-separated list of fields). If this is done, the above six columns be present. Extra columns will be ignored.
