### PR TITLE
Config info can now be seen when using the lumi checkpoint info feature.

### DIFF
--- a/luminoth/tools/checkpoint/__init__.py
+++ b/luminoth/tools/checkpoint/__init__.py
@@ -366,7 +366,8 @@ def list():
 
 @click.command(help='Display detailed information on checkpoint.')
 @click.argument('id_or_alias')
-def info(id_or_alias):
+@click.option('--config-info','-config','-c', is_flag=True)
+def info(id_or_alias, config_info):
     db = read_checkpoint_db()
 
     checkpoint = get_checkpoint(db, id_or_alias)
@@ -396,6 +397,10 @@ def info(id_or_alias):
     ))
 
     click.echo()
+
+    if config_info:
+        path = get_checkpoint_path(checkpoint['id'])
+        click.echo(get_checkpoint_config('accurate'))
 
     click.echo('Creation date: {}'.format(checkpoint['created_at']))
     click.echo('Luminoth version: {}'.format(checkpoint['luminoth_version']))


### PR DESCRIPTION
lumi checkpoint info <id or alias> -config

displays the config info