### PR TITLE
docs: fix simple typo, targers -> targets

### DIFF
--- a/luminoth/models/fasterrcnn/rpn_target.py
+++ b/luminoth/models/fasterrcnn/rpn_target.py
@@ -92,7 +92,7 @@ class RPNTarget(snt.AbstractModule):
                 The last dimension is used for the label.
             im_shape:
                 Shape of original image (height, width) in order to define
-                anchor targers in respect with gt_boxes.
+                anchor targets in respect with gt_boxes.
 
         Returns:
             Tuple of the tensors of:


### PR DESCRIPTION
There is a small typo in luminoth/models/fasterrcnn/rpn_target.py.

Should read `targets` rather than `targers`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md